### PR TITLE
Bt wp fb

### DIFF
--- a/behaviours/smarc_bt/launch/smarc_bt.launch
+++ b/behaviours/smarc_bt/launch/smarc_bt.launch
@@ -1,9 +1,12 @@
 <launch>
     <arg name="robot_name" default="sam0"/>
+    <arg name="use_sim_time" default="true"/>
     
     <group>
     <push-ros-namespace namespace="$(var robot_name)"/>
-            <node name="smarc_bt" pkg="smarc_bt" exec="smarc_bt" output="screen"/>
+            <node name="smarc_bt" pkg="smarc_bt" exec="smarc_bt" output="screen">
+                <param name="use_sim_time" value="$(var use_sim_time)" />
+            </node>
     </group>
 
 </launch>

--- a/behaviours/smarc_bt/smarc_bt/bt/ros_bt.py
+++ b/behaviours/smarc_bt/smarc_bt/bt/ros_bt.py
@@ -71,7 +71,8 @@ class BT(HasVehicleContainer, HasClock):
     
     def _liveliness_tree(self):
         liveliness_tree = Parallel("P_Liveliness", policy=ParallelPolicy.SuccessOnAll(synchronise=False) , children=[
-            A_WaitForData(self, SensorNames.VEHICLE_HEALTHY)
+            A_WaitForData(self, SensorNames.VEHICLE_HEALTHY),
+            A_WaitForData(self, SensorNames.POSITION)
             # Maybe add other sensors too, depth, altitude?
         ])
 

--- a/behaviours/smarc_bt/smarc_bt/bt/ros_bt.py
+++ b/behaviours/smarc_bt/smarc_bt/bt/ros_bt.py
@@ -108,6 +108,7 @@ class BT(HasVehicleContainer, HasClock):
 
         follow_wp_plan = Sequence("S_Follow_WP_Plan", memory=False, children=[
             C_CheckMissionPlanState(MissionPlanStates.RUNNING),
+            A_UpdateMissionPlan(MissionPlan.publish_current_wp),
             A_ActionClient(client=self._goto_wp_action),
             A_UpdateMissionPlan(MissionPlan.complete_current_wp)
         ])

--- a/behaviours/smarc_bt/smarc_bt/bt/ros_bt.py
+++ b/behaviours/smarc_bt/smarc_bt/bt/ros_bt.py
@@ -108,7 +108,6 @@ class BT(HasVehicleContainer, HasClock):
 
         follow_wp_plan = Sequence("S_Follow_WP_Plan", memory=False, children=[
             C_CheckMissionPlanState(MissionPlanStates.RUNNING),
-            A_UpdateMissionPlan(MissionPlan.publish_current_wp),
             A_ActionClient(client=self._goto_wp_action),
             A_UpdateMissionPlan(MissionPlan.complete_current_wp)
         ])

--- a/behaviours/smarc_bt/smarc_bt/mission/mission_plan.py
+++ b/behaviours/smarc_bt/smarc_bt/mission/mission_plan.py
@@ -119,6 +119,9 @@ class MissionPlan():
         if self._current_wp_index >= len(self._waypoints):
             self.complete()
 
+    def publish_current_wp(self):
+        self._log(self._waypoints[self._current_wp_index])
+
     @property
     def current_wp(self):
         if self._state != MissionPlanStates.RUNNING: return None

--- a/behaviours/smarc_bt/smarc_bt/mission/mission_plan.py
+++ b/behaviours/smarc_bt/smarc_bt/mission/mission_plan.py
@@ -119,8 +119,6 @@ class MissionPlan():
         if self._current_wp_index >= len(self._waypoints):
             self.complete()
 
-    def publish_current_wp(self):
-        self._log(self._waypoints[self._current_wp_index])
 
     @property
     def current_wp(self):

--- a/behaviours/smarc_bt/smarc_bt/mission/ros_goto_waypoint.py
+++ b/behaviours/smarc_bt/smarc_bt/mission/ros_goto_waypoint.py
@@ -9,6 +9,7 @@ from .i_action_client import IActionClient, ActionClientState
 
 from smarc_mission_msgs.action import GotoWaypoint
 from smarc_mission_msgs.msg import Topics as MissionTopics
+from smarc_mission_msgs.msg import GotoWaypoint as GotoWaypointMsg
 
 
 class ROSGotoWaypoint(IActionClient):
@@ -25,6 +26,8 @@ class ROSGotoWaypoint(IActionClient):
         self._goal_handle = None
         self._get_result_future = None
         self._feedback_message = "Only initialized"
+
+        self._last_wp_pub = node.create_publisher(GotoWaypointMsg, MissionTopics.BT_LAST_WP_TOPIC, 10)
 
     
     @property
@@ -112,6 +115,8 @@ class ROSGotoWaypoint(IActionClient):
                                                           feedback_callback=self._server_feedback_cb)
         self._send_goal_future.add_done_callback(self._goal_response_cb)
         self._change_state(ActionClientState.SENT)
+
+        self._last_wp_pub.publish(wp.goto_wp)
 
 
     def cancel_goal(self):

--- a/behaviours/smarc_bt/smarc_bt/mission/ros_mission_plan.py
+++ b/behaviours/smarc_bt/smarc_bt/mission/ros_mission_plan.py
@@ -6,7 +6,6 @@ from .ros_waypoint import ROSWP
 from .mission_plan import MissionPlan, MissionPlanStates
 
 from smarc_mission_msgs.msg import Topics as MissionTopics, MissionControl
-from smarc_mission_msgs.msg import GotoWaypoint
 
 from std_msgs.msg import Empty
 
@@ -28,7 +27,7 @@ class ROSMissionPlan(MissionPlan):
         self._mission_control_pub = node.create_publisher(MissionControl,
                                                           MissionTopics.MISSION_CONTROL_TOPIC,
                                                           10)
-        self._last_wp_pub = node.create_publisher(GotoWaypoint, MissionTopics.BT_LAST_WP_TOPIC, 10)
+        
         self._publish_mission()
         
 
@@ -66,13 +65,8 @@ class ROSMissionPlan(MissionPlan):
         self._feedback_message = f"Published plan:{mc.name} with {len(mc.waypoints)} wps"
         return True
 
-    def publish_current_wp(self):
-        current_wp = self._waypoints[self._current_wp_index]
-        if(type(current_wp) != ROSWP):
-            self._feedback_message = f"Plan {self._plan_id} had a non-ros WP in it when trying to publish it"
-            return
+
         
-        self._last_wp_pub.publish(current_wp.goto_wp)
 
     def _change_state(self, new_state: MissionPlanStates) -> bool:
         self._publish_mission()

--- a/behaviours/smarc_bt/smarc_bt/mission/ros_mission_plan.py
+++ b/behaviours/smarc_bt/smarc_bt/mission/ros_mission_plan.py
@@ -6,6 +6,7 @@ from .ros_waypoint import ROSWP
 from .mission_plan import MissionPlan, MissionPlanStates
 
 from smarc_mission_msgs.msg import Topics as MissionTopics, MissionControl
+from smarc_mission_msgs.msg import GotoWaypoint
 
 from std_msgs.msg import Empty
 
@@ -23,10 +24,11 @@ class ROSMissionPlan(MissionPlan):
         super().__init__(plan_id, hash, timeout, waypoints)
         self._node = node
 
-        self._complete_pub = self._node.create_publisher(Empty, MissionTopics.MISSION_COMPLETE_TOPIC, 10)
+        self._complete_pub = node.create_publisher(Empty, MissionTopics.MISSION_COMPLETE_TOPIC, 10)
         self._mission_control_pub = node.create_publisher(MissionControl,
                                                           MissionTopics.MISSION_CONTROL_TOPIC,
                                                           10)
+        self._last_wp_pub = node.create_publisher(GotoWaypoint, MissionTopics.BT_LAST_WP_TOPIC, 10)
         self._publish_mission()
         
 
@@ -64,6 +66,13 @@ class ROSMissionPlan(MissionPlan):
         self._feedback_message = f"Published plan:{mc.name} with {len(mc.waypoints)} wps"
         return True
 
+    def publish_current_wp(self):
+        current_wp = self._waypoints[self._current_wp_index]
+        if(type(current_wp) != ROSWP):
+            self._feedback_message = f"Plan {self._plan_id} had a non-ros WP in it when trying to publish it"
+            return
+        
+        self._last_wp_pub.publish(current_wp.goto_wp)
 
     def _change_state(self, new_state: MissionPlanStates) -> bool:
         self._publish_mission()

--- a/behaviours/smarc_bt/smarc_bt/vehicles/ros_vehicle.py
+++ b/behaviours/smarc_bt/smarc_bt/vehicles/ros_vehicle.py
@@ -60,7 +60,7 @@ class ROSVehicle(IVehicleStateContainer):
                                                           self._vehicle_state._reference_frame,
                                                           time.Time())
         except Exception as ex:
-            self._log(f"Vehicle state could not update position, exception:\n{ex}")
+            #self._log(f"Vehicle state could not update position, exception:\n{ex}")
             return
     
         seconds = tf_stamped.header.stamp.sec

--- a/gui/smarc_nodered/config/mqtt_config.yaml
+++ b/gui/smarc_nodered/config/mqtt_config.yaml
@@ -12,7 +12,7 @@
         deserializer: json:loads
         # this needs to be set accordingly 
         # TODO maybe modify the mqtt_brdige to acquire these from the yaml directly?
-        n_bridges: 19
+        n_bridges: 22
         bridge:
             # dont forget to add the ".msg" part!
             #  the ~ in front will fill with smarc/<robot_name>/ for mqtt
@@ -38,17 +38,18 @@
             bridge12: ["mqtt_bridge.bridge:RosToMqttBridge", "std_msgs.msg:Float64", "dr/yaw", "~/dr/yaw"]
             bridge13: ["mqtt_bridge.bridge:RosToMqttBridge", "std_msgs.msg:Float64", "dr/altitude", "~/dr/altitude"]
             bridge14: ["mqtt_bridge.bridge:RosToMqttBridge", "std_msgs.msg:Float64", "dr/depth", "~/dr/depth"]
+            bridge15: ["mqtt_bridge.bridge:RosToMqttBridge", "std_msgs.msg:Float64", "dr/compass_heading", "~/dr/compass_heading"]
             # bt stuff
-            bridge15: ["mqtt_bridge.bridge:RosToMqttBridge", "smarc_mission_msgs.msg:MissionControl", "mission/mission_control", "~/bt/mission_control"]
-            bridge16: ["mqtt_bridge.bridge:RosToMqttBridge", "smarc_mission_msgs.msg:BTCommand", "mission/bt_command", "~/bt/bt_cmd"]
-            bridge17: ["mqtt_bridge.bridge:RosToMqttBridge", "std_msgs.msg:Empty", "core/heartbeat", "~/bt/heartbeat"]
-            bridge18: ["mqtt_bridge.bridge:RosToMqttBridge", "py_trees_ros_interfaces.msg:Behaviour", "mission/bt_tip", "~/bt/tip"]
-            bridge19: ["mqtt_bridge.bridge:RosToMqttBridge", "smarc_mission_msgs.msg:GotoWaypoint", "mission/last_wp", "~/bt/last_wp"]
+            bridge16: ["mqtt_bridge.bridge:RosToMqttBridge", "smarc_mission_msgs.msg:MissionControl", "mission/mission_control", "~/bt/mission_control"]
+            bridge17: ["mqtt_bridge.bridge:RosToMqttBridge", "smarc_mission_msgs.msg:BTCommand", "mission/bt_command", "~/bt/bt_cmd"]
+            bridge18: ["mqtt_bridge.bridge:RosToMqttBridge", "std_msgs.msg:Empty", "core/heartbeat", "~/bt/heartbeat"]
+            bridge19: ["mqtt_bridge.bridge:RosToMqttBridge", "py_trees_ros_interfaces.msg:Behaviour", "mission/bt_tip", "~/bt/tip"]
+            bridge20: ["mqtt_bridge.bridge:RosToMqttBridge", "smarc_mission_msgs.msg:GotoWaypoint", "mission/last_wp", "~/bt/last_wp"]
             ###
             # MQTT -> ROS
             ###
-            bridge19: ["mqtt_bridge.bridge:MqttToRosBridge", "smarc_mission_msgs.msg:MissionControl", "~/bt_cmd/mission_control", "mission/mission_control"]
-            bridge20: ["mqtt_bridge.bridge:MqttToRosBridge", "smarc_mission_msgs.msg:BTCommand", "~/bt_cmd/bt_cmd", "mission/bt_command"]
+            bridge21: ["mqtt_bridge.bridge:MqttToRosBridge", "smarc_mission_msgs.msg:MissionControl", "~/bt_cmd/mission_control", "mission/mission_control"]
+            bridge22: ["mqtt_bridge.bridge:MqttToRosBridge", "smarc_mission_msgs.msg:BTCommand", "~/bt_cmd/bt_cmd", "mission/bt_command"]
 
 
 

--- a/messages/smarc_mission_msgs/msg/Topics.msg
+++ b/messages/smarc_mission_msgs/msg/Topics.msg
@@ -5,5 +5,6 @@ string MISSION_COMPLETE_TOPIC = 'mission/complete'
 string MISSION_CONTROL_TOPIC = 'mission/mission_control'
 string BT_COMMAND_TOPIC = 'mission/bt_command'
 string BT_TIP_TOPIC = 'mission/bt_tip'
+string BT_LAST_WP_TOPIC = 'mission/last_wp'
 
 string GOTO_WP_ACTION = 'mission/goto_wp_action'


### PR DESCRIPTION
BT now publishes the last WP it sent to the action server for the GUI to display. 
MQTT bridge now reads `dr/compass_heading` and the GUI displays this instead of `dr/yaw` on the map for robots named like `<WHATEVER>sam<NUMBER>`. 