### PR TITLE
Read out robot name from command line argument

### DIFF
--- a/behaviours/dive_control/dive_control/DiveController.py
+++ b/behaviours/dive_control/dive_control/DiveController.py
@@ -36,8 +36,9 @@ class DiveController():
         self._tf_buffer = Buffer()
         self._tf_listener = TransformListener(self._tf_buffer, self._node)
 
-        # TODO: Can we get this from a launch file or so?
-        self._robot_base_link = 'sam0/base_link_gt'
+        # We need to declare the parameter we want to read out from the alunch file first.
+        self._node.declare_parameter('robot_name')
+        self._robot_base_link = self._node.get_parameter('robot_name').get_parameter_value().string_value + '/base_link_gt'
 
         self._depth_setpoint = None
         self._pitch_setpoint = None

--- a/behaviours/dive_control/launch/actionserver.launch
+++ b/behaviours/dive_control/launch/actionserver.launch
@@ -4,7 +4,9 @@
    
     <group>
     <push-ros-namespace namespace="$(var robot_name)"/>
-       <node name="diving" pkg="dive_control" exec="action_server_diving" output="screen"/>
+       <node name="diving" pkg="dive_control" exec="action_server_diving" output="screen">
+        <param name="robot_name" value="$(var robot_name)"/>
+       </node>
     </group>
 
 </launch>

--- a/scripts/smarc_bringups/scripts/sam_bringup.sh
+++ b/scripts/smarc_bringups/scripts/sam_bringup.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-ROBOT_NAME=sam0
+ROBOT_NAME=sam_auv_v1
 SESSION=${ROBOT_NAME}_bringup
 
 # create a tmux session with a name


### PR DESCRIPTION
Now we don't need to check which robot we're actually using, but can use the same code for as many as we want.

Changed the robot name to the current one in the sim.