### PR TITLE
Creating SMaRC custom typestore implementation that is reusable and path independent

### DIFF
--- a/scripts/rosbag_analyzer/README.md
+++ b/scripts/rosbag_analyzer/README.md
@@ -6,7 +6,7 @@ plots. Or you want to do post-processing with the latest cutting edge filtering
 algorithm. Either way, you want to get the data out of the ros bag.
 
 ## Prerequesits
-[Rosbags package](https://ternaris.gitlab.io/rosbags/index.html), install with 
+[Rosbags package](https://ternaris.gitlab.io/rosbags/index.html), install with
 ```shell
 pip install rosbags
 ```
@@ -16,10 +16,10 @@ TL;DR: Change the file path to the **directory** with the ros bag, choose the
 topics you want, save the data, here I used dictionaries with lists.
 
 ### Longer version
-We have custom message types that we need to register with the package. This
-happens in the first for-loop. In the script, I did it for three message types,
-`ControlInput.mgs`, `ControlState.msg`, `State.msg`. If you have other custom
-message types, adjust the path and the messages you iterate over. If you only have the default ROS message types, you can ignore this. 
+We have custom message types that we need to register with the package.
+A generic solution has been implemented for smarc in the `rosbag_types.py` that imports all
+the custom types in `smarc2/messages/` to be a convenient solution for all. See the example in the script
+or in the documentation of the class.
 
 The ros bag contains the `/parameter_events` topic, which records when a
 ROS 2 parameter gets changed. I use this to change the trajectory and wanted to

--- a/scripts/rosbag_analyzer/rosbag_analyzer.py
+++ b/scripts/rosbag_analyzer/rosbag_analyzer.py
@@ -8,36 +8,14 @@ from rosbags.typesys import Stores, get_types_from_msg, get_typestore
 import numpy as np
 import matplotlib.pyplot as plt
 
-# For custom messages, we have to register the message type. Otherwise
-# the reader doesn't know what to do.
-def guess_msgtype(path: Path) -> str:
-    """Guess message type name from path."""
-    name = path.relative_to(path.parents[2]).with_suffix('')
-    if 'msg' not in name.parts:
-        name = name.parent / 'msg' / name.name
-    return str(name)
+from rosbag_types import SmarcRosbagTypestore
 
-# Get all default ROS2 message types
-typestore = get_typestore(Stores.ROS2_HUMBLE)
-add_types = {}
-
-# Directory with the custom message definitions. Assumes the ros WS is in the
-# home directory
-home = str(Path.home())
-message_dir = home + '/ros2_ws/src/smarc2/messages/smarc_control_msgs/msg/'
-
-# All custom message files have to be specified here
-for pathstr in [message_dir + 'ControlInput.msg',
-                message_dir + 'ControlState.msg', message_dir + 'State.msg']:
-    msgpath = Path(pathstr)
-    msgdef = msgpath.read_text(encoding='utf-8')
-    add_types.update(get_types_from_msg(msgdef, guess_msgtype(msgpath)))
-
-typestore.register(add_types)
+smarc_types = SmarcRosbagTypestore()
+typestore = smarc_types.construct_custom_typestore()
 
 # Path to the directory with the rosbag. Not the rosbag itself
 # due to the way ros2 records bags now.
-file ='./rosbag2_2024_10_15-11_47_37'
+file ='src/smarc2/scripts/rosbag_analyzer/rosbag2_2024_10_15-11_47_37'
 
 states = {}
 states["t"] = []
@@ -67,7 +45,7 @@ with Reader(file) as reader:
             states["t"].append(msg.header.stamp.sec + 1e-9 * msg.header.stamp.nanosec)
 
     print("Bag read")
-    
+
 events["trig"] = np.ones((len(events["t"])))
 
 fig = plt.figure()
@@ -94,8 +72,3 @@ plt.xlabel("x / m")
 plt.ylabel("y / m")
 
 plt.show()
-
-
-
-
-

--- a/scripts/rosbag_analyzer/rosbag_types.py
+++ b/scripts/rosbag_analyzer/rosbag_types.py
@@ -96,10 +96,3 @@ class SmarcRosbagTypestore:
         ros_message = split_path[-3:]
         joined_name = r"/".join(ros_message)
         return joined_name.split('.')[0]
-
-if __name__ == "__main__":
-    smarc_types = SmarcRosbagTypestore()
-    print(smarc_types._script_path)
-    print(smarc_types._glob_path)
-    smarc_types.find_all_msg_files()
-    smarc_types.construct_custom_typestore()

--- a/scripts/rosbag_analyzer/rosbag_types.py
+++ b/scripts/rosbag_analyzer/rosbag_types.py
@@ -1,0 +1,93 @@
+import os
+from glob import glob
+import pathlib
+from typing import List
+
+from rosbags.typesys import get_typestore, get_types_from_msg, Stores, store
+
+class SmarcRosbagTypestore:
+    """User path and configuration independent SMaRC typestore constructor for rosbags.
+
+        WARN: Still dependent on repo configuration and message location within repo.
+
+        # Example usage:
+        ```
+            from rosbag_types import SmarcRosbagTypestore
+
+            smarc_types = SmarcRosbagTypestore()
+            typestore = smarc_types.construct_custom_typestore()
+
+            # Example iteration through rosbag can be found here:
+            # https://ternaris.gitlab.io/rosbags/topics/rosbag2.html#reading-rosbag2
+            # All items are the same just use the extended typestore with SMaRC custom messages
+    """
+    def __init__(self):
+        self.typestore = get_typestore(Stores.ROS2_HUMBLE)
+        self.script_path = pathlib.Path(__file__).parent.resolve()
+        self.glob_path = self._construct_glob_path()
+        self.message_paths = []
+        self.custom_types = {}
+
+
+    def _construct_glob_path(self):
+        """Constructs glob path for finding all message files within repository.
+
+            WARN: constructs relative to this files location
+        """
+        glob_path = self.script_path.parent.parent.resolve()
+        glob_path = glob_path / "messages/**/*.msg"
+        return glob_path
+
+    def find_all_msg_files(self) -> List[str]:
+        """Finds all smarc msg files located in smarc2/messages folder structure
+            Updates internal class structure.
+        Returns:
+            list of all absolute paths to messages files
+        """
+        # glob requires a string, which is annoying, and I don't like the Path Glob
+        self.message_paths = glob(str(self.glob_path), recursive=True)
+        return self.message_paths
+
+    def construct_custom_typestore(self) -> store.Typestore:
+        """Constructs custom typestore by guessing at message format name.
+
+            Format internal to repo is generally as follows:
+                `folder/msg/MsgName`
+            Examples include: `smarc_msgs/msg/PercentStamped`
+            Examples include: `sensor_msgs/msg/Imu`
+        """
+        self.find_all_msg_files()
+        for msg_file in self.message_paths:
+            msg_name = self.reconstruct_message_name(msg_file)
+            msg_text = pathlib.Path(msg_file).read_text()
+            msg_type = get_types_from_msg(msg_text, msg_name)
+            self.custom_types.update(msg_type)
+        self.typestore.register(self.custom_types)
+        return self.typestore
+
+
+    @staticmethod
+    def reconstruct_message_name(msg_path) -> str:
+        """Guesses at message name structure for ROS typestore.
+
+            Format internal to repo is generally as follows:
+                `folder/msg/MsgName`
+            Examples include: `smarc_msgs/msg/PercentStamped`
+            Examples include: `sensor_msgs/msg/Imu`
+
+            Args:
+                msg_path: absolute path of message filew
+            Returns:
+                message name within SMaRC system
+        """
+        split_path = msg_path.split("/")
+        ros_message = split_path[-3:]
+        joined_name = r"/".join(ros_message)
+        return joined_name.split('.')[0]
+
+if __name__ == "__main__":
+    smarc_types = SmarcRosbagTypestore()
+    print(smarc_types.script_path)
+    print(smarc_types.glob_path)
+    smarc_types.find_all_msg_files()
+    smarc_types.construct_custom_typestore()


### PR DESCRIPTION
Why:
- Constructing the typestore is inconvenient and requires globing across multiple folders and files
- Saw a custom script using similar one off implementations and imagine more people will need this functionality in the future

How:
- Constructed all paths relative to script location, which will only need to change if script gets moved rather than on a per user basis

Additional Info:
- Updated the one off script to use custom typestore and abstracting away all the globing etc
- Deleted now duplicate code