### PR TITLE
make auv_detector work in hdrp  with correct ReadMe

### DIFF
--- a/perception/auv_detector/README.md
+++ b/perception/auv_detector/README.md
@@ -104,8 +104,9 @@ This is suitable when you need simultaneous estimation and detection.
 ## Tune Parameters
 
 ### 1. `manual_hsv_detector.py`
-This python file helps users to adjust hsv thresholds for their targets. This is the tutorial video: https://youtu.be/s7yu1LuMguQ
-Get the lower and upper bound to adjust the hsv threshold in KNN.py
+This python file helps users to adjust hsv thresholds for their targets. 
+- Get the lower and upper bound to adjust the hsv threshold in KNN.py
+- This is the tutorial video: https://youtu.be/s7yu1LuMguQ.
 
 #### Usage
 ```bash

--- a/perception/auv_detector/README.md
+++ b/perception/auv_detector/README.md
@@ -101,6 +101,23 @@ This is suitable when you need simultaneous estimation and detection.
 
 ---
 
+## Tune Parameters
+
+### 1. `manual_hsv_detector.py`
+This python file helps users to adjust hsv thresholds for their targets. This is the tutorial video: https://youtu.be/s7yu1LuMguQ
+Get the lower and upper bound to adjust the hsv threshold in KNN.py
+
+#### Usage
+```bash
+ros2 run auv_detector manual_hsv_detector
+```
+
+### 2. `params_detector.py`
+This python files provide variable `REALDATA`. When set it as True, the detector will use the pre-recorded mp4.data
+When set it False, the detector will use the real-time simulation in Unity.
+
+---
+
 ## Why These Techniques?
 
 - **KNN for Detection**: KNN is simple and effective when you have labeled sensor data. It's also non-parametric, meaning it doesn’t make strong assumptions about the data distribution, making it versatile in changing environments.

--- a/perception/auv_detector/README.md
+++ b/perception/auv_detector/README.md
@@ -114,8 +114,8 @@ This is suitable when you need simultaneous estimation and detection.
 1. Make sure your ROS 2 system is set up correctly with the necessary dependencies.
 2. Ensure the drone is publishing sensor data, such as IMU and GPS.
 3. Run the appropriate launch file based on your task:
-   - For **only detection**: `ros2 launch state_estimation detector_only.launch.xml`
-   - For **estimation and detection**: `ros2 launch state_estimation estimator_detector.launch.xml`
+   - For **only detection**: `ros2 launch auv_detector detector_only.launch`
+   - For **estimation and detection**: `ros2 launch auv_detector estimator_detector.launch`
 
 4. Verify that the nodes are receiving the data correctly, and check the console output for any state or detection information.
 

--- a/perception/auv_detector/README.md
+++ b/perception/auv_detector/README.md
@@ -114,7 +114,7 @@ ros2 run auv_detector manual_hsv_detector
 ```
 
 ### 2. `params_detector.py`
-This python files provide variable `REALDATA`. When set it as True, the detector will use the pre-recorded mp4.data
+This python file includes the variable `REALDATA`. When set it as True, the detector will use the pre-recorded mp4.data
 When set it False, the detector will use the real-time simulation in Unity.
 
 ---

--- a/perception/auv_detector/README.md
+++ b/perception/auv_detector/README.md
@@ -81,21 +81,21 @@ This script implements the EKF, which operates similarly to the Kalman Filter bu
 
 ## Launch Files
 
-### 1. `detector_only.launch.xml`
+### 1. `detector_only.launch`
 This launch file starts only the `detector` node, which executes the KNN-based detection algorithm.
 
 #### Usage
 ```bash
-ros2 launch state_estimation detector_only.launch.xml
+ros2 launch auv_detector detector_only.launch
 ```
 This is useful in cases where only object detection is required without running the state estimator.
 
-### 2. `estimator_detector.launch.xml`
+### 2. `estimator_detector.launch`
 This launch file starts both the `estimator` and `detector` nodes, allowing both state estimation and object detection to run simultaneously.
 
 #### Usage
 ```bash
-ros2 launch state_estimation estimator_detector.launch.xml
+ros2 launch auv_detector estimator_detector.launch
 ```
 This is suitable when you need simultaneous estimation and detection.
 

--- a/perception/auv_detector/auv_detector/manual_hsv_detector.py
+++ b/perception/auv_detector/auv_detector/manual_hsv_detector.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import cv2
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Image
+from cv_bridge import CvBridge, CvBridgeError
+import argparse
+
+
+# HSV  buoy [16 0 255]  ~ [25 152 255]  orange color
+# HSV  auv  [0 55 153] ~ [195 97 254]  yellow color
+
+def setup_trackbars(range_filter):
+    cv2.namedWindow("Trackbars", 0)
+    for i in ["MIN", "MAX"]:
+        v = 0 if i == "MIN" else 255
+        for j in range_filter:
+            cv2.createTrackbar(f"{j}_{i}", "Trackbars", v, 255, lambda x: None)
+
+
+def get_trackbar_values(range_filter):
+    values = []
+    for i in ["MIN", "MAX"]:
+        for j in range_filter:
+            v = cv2.getTrackbarPos(f"{j}_{i}", "Trackbars")
+            values.append(v)
+    return values
+
+
+class HSVDetectorNode(Node):
+    def __init__(self, image_path=None):
+        super().__init__('hsv_detector')
+        self.bridge = CvBridge()
+        self.image_path = image_path
+        self.cv2_img = None
+        self.range_filter = "HSV"
+
+        setup_trackbars(self.range_filter)
+
+        if not self.image_path:
+            self.subscription = self.create_subscription(
+                Image,
+                '/Quadrotor/core/fpcamera/image',
+                self.image_callback,
+                10
+            )
+            self.get_logger().info("Subscribed to /Quadrotor/core/fpcamera/image")
+
+    def image_callback(self, msg):
+        try:
+            self.cv2_img = self.bridge.imgmsg_to_cv2(msg, "bgr8")
+        except CvBridgeError as e:
+            self.get_logger().error(f"CvBridge Error: {e}")
+
+    def process_image(self, image):
+        frame_to_thresh = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        v1_min, v2_min, v3_min, v1_max, v2_max, v3_max = get_trackbar_values(self.range_filter)
+        thresh = cv2.inRange(frame_to_thresh, (v1_min, v2_min, v3_min), (v1_max, v2_max, v3_max))
+        preview = cv2.bitwise_and(image, image, mask=thresh)
+        return preview
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(description="HSV Detector for ROS 2")
+    parser.add_argument("-i", "--image", required=False, help="Path to input static image")
+    parsed_args, unknown = parser.parse_known_args()
+
+    rclpy.init(args=unknown)
+    node = HSVDetectorNode(image_path=parsed_args.image)
+
+    try:
+        if parsed_args.image:
+            image = cv2.imread(parsed_args.image)
+            if image is None:
+                node.get_logger().error(f"Failed to load image from {parsed_args.image}")
+                return
+            while True:
+                preview = node.process_image(image)
+                cv2.imshow("Preview", preview)
+                if cv2.waitKey(1) & 0xFF == ord('q'):
+                    break
+        else:
+            while rclpy.ok():
+                rclpy.spin_once(node, timeout_sec=0.1)
+                if node.cv2_img is not None:
+                    preview = node.process_image(node.cv2_img)
+                    cv2.imshow("Preview", preview)
+                    if cv2.waitKey(1) & 0xFF == ord('q'):
+                        break
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+        cv2.destroyAllWindows()
+
+
+if __name__ == '__main__':
+    main()

--- a/perception/auv_detector/auv_detector/params_detector.py
+++ b/perception/auv_detector/auv_detector/params_detector.py
@@ -25,5 +25,5 @@ SAM_COLOR = [91,96,61]
 BEST_FIT_DEGREE = 3
 #TOPIC TO PUBLISH REAL VIDEO IMAGES
 REALDATA_TOPIC = 'realdata/camera/image'
-REALDATA = True
+REALDATA = False
 REALDATA_PATH = "/home/schnizzle/Downloads/real_sam_data.MP4"


### PR DESCRIPTION
there is no error now. auv_detector can work now
The culprit is the REALDATA = True in params_detector.py
I use r**os2 node info /detector_node** and find the issue. 
The simulation_config.yaml file does not correctly overwrite the the REALDATA = Ture in params_detector.py


When it works, It will published
/Quadrotor/core/fpcamera/image_processed
/Quadrotor/auv/buoy_est
/Quadrotor/auv/sam_lowest_est
when subscribe **/Quadrotor/core/fpcamera/image_processed**
For only detection: ros2 launch auv_detector detector_only.launch (**plot green circles**)
For estimation and detection: ros2 launch auv_detector estimator_detector.launch (**plot green and red circles and a big blue circle**)
Here is the demo video:
https://youtu.be/2LGCUtSxTaI

The recognition rate may be not perfect.
Aryan mentions they work for a certain height, he had tuned them for **~7m.**

Please remember to turn off sonar in unity
https://youtu.be/ILCP1qDukWE

I will tune three heights parameters of color bounds and then interpolation for the future deployment, or CNN. 
 
