### PR TITLE
get_ready functionality incorporated

### DIFF
--- a/behaviours/wasp_bt/wasp_bt/bt/conditions.py
+++ b/behaviours/wasp_bt/wasp_bt/bt/conditions.py
@@ -156,13 +156,23 @@ class C_LastHealthy(Behaviour):
             self.feedback_message = "Comms are fine. Vehicle health is up to date."
             return Status.SUCCESS
 
+
 class C_VehicleHealthStatus(Behaviour):
-    def __init__(self, wara_ps_task_handler: WaraPSTaskHandler):
+    def __init__(self, wara_ps_task_handler: WaraPSTaskHandler, desired_status: Topics):
         """
         Returns S if the vehicle is healthy
         """
         self._wara_ps_task_handler = wara_ps_task_handler
-        name = f"{self.__class__.__name__}"
+        self._desired_status = desired_status
+
+        self.status_dict = {
+            0: "READY",
+            1: "WAITING",
+            2: "ERROR"
+        }
+        
+        desired_status_str = self.status_dict[desired_status]
+        name = f"{self.__class__.__name__}({desired_status_str})"
         super().__init__(name)
         self._health_status = self._wara_ps_task_handler.health_status
         self.feedback_message = ""
@@ -172,17 +182,11 @@ class C_VehicleHealthStatus(Behaviour):
         # update the health status from the task handler
         self._health_status = self._wara_ps_task_handler.health_status
 
-        if self._health_status == Topics.VEHICLE_HEALTH_READY:
+        if self._health_status == self._desired_status:
             self.feedback_message = f"Vehicle health status is {self._health_status}"
             return Status.SUCCESS
-        elif self._health_status == Topics.VEHICLE_HEALTH_WAITING:
-            self.feedback_message = f"Vehicle health status is {self._health_status}. Waiting for recovery."
-            return Status.RUNNING
-        elif self._health_status == Topics.VEHICLE_HEALTH_ERROR:
-            self.feedback_message = f"Vehicle health status is {self._health_status}. Aborting mission."
-            return Status.FAILURE
         else:
-            self.feedback_message = f"Vehicle health status is {self._health_status}. Unknown status."
+            self.feedback_message = f"Vehicle health status is {self._health_status}. Unknown status"
             return Status.FAILURE
 
         

--- a/behaviours/wasp_bt/wasp_bt/bt/ros_bt.py
+++ b/behaviours/wasp_bt/wasp_bt/bt/ros_bt.py
@@ -13,6 +13,7 @@ from py_trees.blackboard import Blackboard
 from py_trees.decorators import Inverter
 from py_trees.common import Status, ParallelPolicy
 from py_trees.behaviours import Running, Success, Failure
+from smarc_msgs.msg import Topics as SMaRCTopics
 
 from ..vehicles.vehicle import IVehicleStateContainer
 from ..vehicles.sensor import SensorNames
@@ -50,6 +51,7 @@ class BT(HasVehicleContainer, HasClock, HasWaraPSTaskHandler):
                  vehicle_container:IVehicleStateContainer,
                  task_handler:WaraPSTaskHandler,
                  now_seconds_func: typing.Callable,
+                 get_ready_action: BTActionClient = None,
                  emergency_action: BTActionClient = None,
                  action_client_list: typing.List[BTActionClient] = None
                  ):
@@ -64,6 +66,7 @@ class BT(HasVehicleContainer, HasClock, HasWaraPSTaskHandler):
         self.action_client_list = action_client_list
         self._now_seconds_func = now_seconds_func
         self.emergency_action = emergency_action
+        self.get_ready_action = get_ready_action
 
         self._last_state_str = ""
 
@@ -90,19 +93,24 @@ class BT(HasVehicleContainer, HasClock, HasWaraPSTaskHandler):
         return liveliness_tree
     
     def _health_tree(self):
+        """
+        A tree that checks the health status of the vehicle
+        """
+
         health_checks = Fallback("F_Health_Handler", memory=False, children=[
             Sequence("S_Health_Status", memory=False, children=[
-                C_HasHeardFromVehicleHealth(self._task_handler),  # check if the vehicle health has been heard from in the last 10 seconds
+                # C_HasHeardFromVehicleHealth(self._task_handler),  # check if the vehicle health returns SUCCESS (Vehicle is ready)
                 C_LastHealthy(self._task_handler, timeout=15.0),  # check if the last heartbeat was within 10 seconds
-                C_VehicleHealthStatus(self._task_handler),
-
+                Fallback("F_Health_Checks", memory=False, children=[
+                    C_VehicleHealthStatus(self._task_handler, desired_status = SMaRCTopics.VEHICLE_HEALTH_READY),
+                    C_VehicleHealthStatus(self._task_handler, desired_status = SMaRCTopics.VEHICLE_HEALTH_WAITING),
+                ]),
             ]),
             A_Abort(self._task_handler),
         ])
 
-        return health_checks                
- 
-   
+        return health_checks
+
     def _handle_emergency_tree(self):
         """
         A tree that handles emergency situations, such as aborting the mission
@@ -156,6 +164,45 @@ class BT(HasVehicleContainer, HasClock, HasWaraPSTaskHandler):
 
         return task_tree
 
+    def _get_ready_tree(self, task_name: str, action_client: BTActionClient):
+        """
+        A tree that handles a single task type, such as move-to or depth-move-to
+        """
+
+
+        # check if the action server is alive (setup like below)
+        status = action_client._setup(num_iters=3)
+        if not status:
+            # if the action server is not alive, we cannot run the action
+            self._task_handler._node.get_logger().warn(f"Action server for {task_name} is not alive")
+            return None
+
+        ready_tree = Sequence(f"S_{task_name}", memory=False, children=[
+
+            Fallback("F_CanIGetReady?", memory=False, children = [
+                C_VehicleHealthStatus(self._task_handler, desired_status = SMaRCTopics.VEHICLE_HEALTH_WAITING),
+                C_VehicleHealthStatus(self._task_handler, desired_status = SMaRCTopics.VEHICLE_HEALTH_READY),
+            ]),
+
+            C_TaskIs(self._task_handler, task_name),
+            Fallback("F_StatusCheck", memory=False, children=[
+                C_TaskStatus(self._task_handler, WaraPSTaskStates.STARTED.value),
+                C_TaskStatus(self._task_handler, WaraPSTaskStates.RESUMED.value),
+                C_TaskStatus(self._task_handler, WaraPSTaskStates.RUNNING.value),
+            ]),
+
+            # run the action client
+            A_ActionClient(
+                action_client,
+                bt = self,
+                task_handler = self._task_handler
+            ),
+            # when done, clear the task queue
+            A_ClearCurrentTask(self._task_handler),
+        ])
+
+        return ready_tree
+
 
     def _task_handler_tree(self, action_client_list: typing.List[BTActionClient] = None):
         """
@@ -170,6 +217,10 @@ class BT(HasVehicleContainer, HasClock, HasWaraPSTaskHandler):
             ]),
         ]
 
+        if self.get_ready_action is not None:
+            get_ready_tree = self._get_ready_tree("get-ready", self.get_ready_action)
+            if get_ready_tree is not None:
+                task_children.append(get_ready_tree)
 
         # create a action_client_list from the heartbeats of action clients, as stored by the WaraPSTaskHandler
 
@@ -182,7 +233,7 @@ class BT(HasVehicleContainer, HasClock, HasWaraPSTaskHandler):
             ros_task_name = tasks_available[i]["ros_name"]
             
             # only append to the list of available task if it's not the emergency task. We don't want emergency to be available to the user in the task handler tree.
-            if "emergency" not in ros_task_name:
+            if "emergency" not in ros_task_name and "ready" not in ros_task_name:
                 ros_task_names.append(ros_task_name)
             
         # self._task_handler._node.get_logger().info(f"Available tasks: {ros_task_names}")
@@ -193,6 +244,11 @@ class BT(HasVehicleContainer, HasClock, HasWaraPSTaskHandler):
             
             action_client_list = [BTActionClient(self._task_handler._node, ros_task_name, action_type) for ros_task_name in ros_task_names]
 
+        mission_children = [
+            C_VehicleHealthStatus(self._task_handler, desired_status=SMaRCTopics.VEHICLE_HEALTH_READY)
+        ]
+
+        mission_task_children = []
 
         # we will append the task trees to this list programmatically
         if action_client_list is not None:
@@ -213,7 +269,20 @@ class BT(HasVehicleContainer, HasClock, HasWaraPSTaskHandler):
                 task_name = action_client.get_action_name().split('/')[-1].replace("_", "-")
 
                 task_tree = self._one_task_tree(task_name, action_client)
-                task_children.append(task_tree)
+                mission_task_children.append(task_tree)
+
+        # make a fallback out of mission_task_children
+        mission_task_fallback = Fallback("F_Tasks", memory=False, children=mission_task_children)
+
+        # add mission_task_fallback to the mission_children
+        mission_children.append(mission_task_fallback)
+
+        # construct the mission tree
+        mission_tree = Sequence("S_Mission", memory=False, children=mission_children)
+
+
+        # add the mission tree to task handler
+        task_children.append(mission_tree)
 
         # add the chill task
         task_children.append(A_Chilling(self))
@@ -291,7 +360,11 @@ def wasp_bt():
     # agent = SAMAuv(node)
     agent = GenericSMaRCVehicle(node, UnderwaterVehicleState)
     action_type = ActionType(BaseAction)
-        
+    
+    # get-ready action client: None if does not exist, else
+    get_ready_action_client = BTActionClient(node, "get_ready", action_type)
+    # get_ready_action_client = None
+
     # emergency action
     emergency_action_client = BTActionClient(node, "emergency_action", action_type)
     # emergency_action_client = None
@@ -331,6 +404,7 @@ def wasp_bt():
     wara_ps_task_handler = WaraPSTaskHandler(node, agent_waraps_dict)
     bt = BT(vehicle_container = agent,
             task_handler    = wara_ps_task_handler,
+            get_ready_action = get_ready_action_client,
             emergency_action = emergency_action_client,
             # action_client_list = action_client_list,
             # the commented out line above means that you're listening for available tasks from the WaraPSTaskHandler. You can also provide a list of action clients to use if you like.


### PR DESCRIPTION
The BT now allows you to handle "get_ready" tasks via dedicated action server even while vehicle is in "waiting" state (precisely to go from waiting to ready in a smooth, autonomous fashion).

If you do not have a "get_ready" action server (with that name), DON'T PANIC! This commit does not break anything, your existing code will work fine. ;)