### PR TITLE
ALARS: captain, bringup, psdk_interfaces

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,7 @@
 	path = simulation/SMARCAssets
 	url = https://github.com/smarc-project/SMARCAssets
 	branch = master
+[submodule "messages/psdk_interfaces"]
+	path = messages/psdk_interfaces
+	url = git@github.com:KKalem/psdk_interfaces.git
+	branch = interfaces_only

--- a/messages/README.md
+++ b/messages/README.md
@@ -28,3 +28,7 @@ This also makes it very easy for IDEs to auto-suggest you the topics~
 Message definitions that don't belong anywhere else.
 
 Contains vehicle-agnostic topics that _all_ vehicles should be aware of at the very least.
+
+
+## psdk_interfaces
+A submodule containing messages related to DJI drones. If you aren't planning on interacting with the drones over ROS, you do not need this submodule.

--- a/scripts/smarc_bringups/README.md
+++ b/scripts/smarc_bringups/README.md
@@ -36,10 +36,8 @@ In the beginning of the script, you can set whether you're on SAM or not.
 
 ### dji_bringup.sh
 
-Launches everything related to DJI drones. 
-You will need this folder: `https://github.com/umdlife/psdk_ros2/tree/main/psdk_interfaces` in your colcon workspace (next to smarc2 is a good place) for the captain to work.
-
-You _could_ clone the whole `psdk_ros2` repo, but it takes forever to build :)
+Launches everything related to DJI drones and the ALARS project.
+**You will need the submodule in `messages/psdk_interfaces` to run the captain this bringup launches.**
 
 
 ## TMUX Cheatsheet

--- a/scripts/smarc_bringups/scripts/dji_bringup.sh
+++ b/scripts/smarc_bringups/scripts/dji_bringup.sh
@@ -2,14 +2,40 @@
 ROBOT_NAME=M350
 SESSION=${ROBOT_NAME}_bringup
 
+MQTT_ADDR=20.240.40.232
+MQTT_PORT=1884
+
 if [[ "$(whoami)" == *"alars"* ]]; then
     USE_SIM_TIME=False
     MAP_FRAME=$ROBOT_NAME/map
+    REALSIM="real"
 else
     USE_SIM_TIME=True
     MAP_FRAME=map_gt
+    REALSIM="simulation"
 fi
 
+# the mqtt stuff on unity on linux is wonky, so use localhost for that
+# a broker will be launched in a tmux pane later.
+if [[ "$(uname)" == "Linux" ]]; then
+    ON_LINUX=True
+else
+    ON_LINUX=False
+fi
+
+
+if [[ $ON_LINUX == "True" && $USE_SIM_TIME == "True" ]]; then
+    MQTT_ADDR=localhost
+    MQTT_PORT=1889
+fi
+
+HOME_ABOVE_WATER=$1
+if [[ -z "$HOME_ABOVE_WATER" ]]; then
+    echo "You must pass the home altitude above water level as the first argument!"
+    echo "This is required for the dji_captain node to function properly."
+    echo "Exiting."
+    exit 1
+fi
 
 # New variables for wasp_bt.launch and wasp_mqtt_agent.launch
 AGENT_TYPE=air
@@ -17,6 +43,8 @@ PULSE_RATE=10.0
 
 # create a tmux session with a name
 tmux -2 new-session -d -s $SESSION
+
+
 
 
 # create a bunch of windows. These are the "tabs" you'll
@@ -27,7 +55,7 @@ tmux -2 new-session -d -s $SESSION
 tmux new-window -t $SESSION:0 -n 'Captains'
 tmux rename-window "Captains"
 # only launch if not the simulator
-if [ "$USE_SIM_TIME" = "False" ]; then
+if [[ $USE_SIM_TIME = "False" ]]; then
     # PSDK_ROS2_BRIDGE
     
     tmux select-window -t $SESSION:0
@@ -43,7 +71,7 @@ if [ "$USE_SIM_TIME" = "False" ]; then
     tmux send-keys "ros2 launch psdk_wrapper wrapper.launch.py namespace:=/$ROBOT_NAME/wrapper" C-m
     
     tmux select-pane -t $SESSION:0.1
-    tmux send-keys "ros2 run dji_captain dji_captain --ros-args -r __ns:=/$ROBOT_NAME" C-m
+    tmux send-keys "ros2 run dji_captain dji_captain --ros-args -p use_sim_time:=$USE_SIM_TIME  -p home_altitude_above_water:=$HOME_ABOVE_WATER -r __ns:=/$ROBOT_NAME " C-m
 
     tmux select-pane -t $SESSION:0.2
     tmux send-keys "fast-discovery-server -i 0" C-m
@@ -55,7 +83,7 @@ else
     tmux select-window -t $SESSION:0
     tmux split-window -h -t $SESSION:0.0
     tmux select-pane -t $SESSION:0.0
-    tmux send-keys "ros2 run dji_captain dji_captain --ros-args -p use_sim_time:=$USE_SIM_TIME -r __ns:=/$ROBOT_NAME" C-m
+    tmux send-keys "ros2 run dji_captain dji_captain --ros-args -p use_sim_time:=$USE_SIM_TIME  -p home_altitude_above_water:=$HOME_ABOVE_WATER -r __ns:=/$ROBOT_NAME " C-m
 
     tmux select-pane -t $SESSION:0.1
     tmux send-keys "ros2 topic echo /$ROBOT_NAME/captain_status std_msgs/msg/String --field data" C-m
@@ -63,8 +91,8 @@ fi
 
 
 # action servers
-tmux new-window -t $SESSION:1 -n 'action servers'
-tmux rename-window "move-to"
+tmux new-window -t $SESSION:1 -n 'Actions'
+tmux rename-window "Actions"
 tmux select-window -t $SESSION:1
 tmux split-window -h -t $SESSION:1.0      # Split window into left (0.0) and right (0.1)
 tmux split-window -v -t $SESSION:1.0      # Split left pane into top-left (0.0) and bottom-left (0.2)
@@ -81,33 +109,39 @@ tmux select-pane -t $SESSION:1.2
 tmux send-keys "ros2 run alars rescuepoint_server --ros-args -p use_sim_time:=$USE_SIM_TIME -r __ns:=/$ROBOT_NAME" C-m
 
 # bt
-tmux new-window -t $SESSION:2 -n 'bt'
-tmux rename-window "bt"
+tmux new-window -t $SESSION:2 -n 'BT'
+tmux rename-window "BT"
 tmux select-window -t $SESSION:2
 tmux send-keys "ros2 launch wasp_bt wasp_bt.launch robot_name:=$ROBOT_NAME agent_type:=$AGENT_TYPE pulse_rate:=$PULSE_RATE use_sim_time:=$USE_SIM_TIME" C-m
 
 
 
 # mqtt bridge
-tmux new-window -t $SESSION:3 -n 'mqtt_bridge'
-tmux rename-window "mqtt_bridge"
+tmux new-window -t $SESSION:3 -n 'MQTTBridge'
+tmux rename-window "MQTTBridge"
 tmux select-window -t $SESSION:3
-if [ "$USE_SIM_TIME" = "True" ]; then
-    tmux send-keys "ros2 launch str_json_mqtt_bridge waraps_bridge.launch robot_name:=$ROBOT_NAME domain:=air realsim:=simulation broker_addr:=20.240.40.232 broker_port:=1884 context:=alars" C-m
-    tmux new-window -t $SESSION:4 -n 'ROS2Bridge'
+tmux send-keys "ros2 launch str_json_mqtt_bridge waraps_bridge.launch robot_name:=$ROBOT_NAME domain:=air realsim:=$REALSIM broker_addr:=$MQTT_ADDR broker_port:=$MQTT_PORT context:=alars" C-m
+
+
+# only needed when running the sim
+if [[ $USE_SIM_TIME = "True" ]]; then
+    # ROS2Bridge
+    tmux new-window -t $SESSION:4 -n 'SimConn'
     tmux select-window -t $SESSION:4
     tmux send-keys "ros2 run ros_tcp_endpoint default_server_endpoint --ros-args -p tcp_ip:=localhost -p tcp_port:=10000" C-m
-else
-    tmux send-keys "ros2 launch str_json_mqtt_bridge waraps_bridge.launch robot_name:=$ROBOT_NAME domain:=air realsim:=real broker_addr:=20.240.40.232 broker_port:=1884 context:=alars" C-m
+    if [[ $ON_LINUX = "True" ]]; then
+        # mqtt broker
+        tmux split-window -h -t $SESSION:4.0
+        tmux select-pane -t $SESSION:4.1
+        tmux send-keys "mosquitto -p $MQTT_PORT" C-m
+    fi
 fi
-
-
 
 # only launch if not the simulator
 # camera node
-if [ "$USE_SIM_TIME" = "False" ]; then
-    tmux new-window -t $SESSION:4 -n 'cam'
-    tmux rename-window "cam"
+if [[ $USE_SIM_TIME = "False" ]]; then
+    tmux new-window -t $SESSION:4 -n 'Cam'
+    tmux rename-window "Cam"
     tmux select-window -t $SESSION:4
     tmux split-window -h -t $SESSION:4.0
     tmux select-pane -t $SESSION:4.0

--- a/scripts/smarc_bringups/scripts/dji_bringup.sh
+++ b/scripts/smarc_bringups/scripts/dji_bringup.sh
@@ -91,8 +91,8 @@ fi
 
 
 # action servers
-tmux new-window -t $SESSION:1 -n 'Actions'
-tmux rename-window "Actions"
+tmux new-window -t $SESSION:1 -n 'ALARSActions'
+tmux rename-window "ALARSActions"
 tmux select-window -t $SESSION:1
 tmux split-window -h -t $SESSION:1.0      # Split window into left (0.0) and right (0.1)
 tmux split-window -v -t $SESSION:1.0      # Split left pane into top-left (0.0) and bottom-left (0.2)
@@ -100,13 +100,17 @@ tmux split-window -v -t $SESSION:1.1      # Split right pane into top-right (0.1
 tmux select-layout -t $SESSION:1 tiled    # Arrange as a 2x2 grid
 
 tmux select-pane -t $SESSION:1.0
-tmux send-keys "ros2 launch go_to_geopoint go_to_geopoint_server.launch robot_name:=$ROBOT_NAME use_sim_time:=$USE_SIM_TIME setpoint_topic:=move_to_setpoint" C-m
+tmux send-keys "echo 'This will be alars-search'" C-m
 
 tmux select-pane -t $SESSION:1.1
-tmux send-keys "ros2 run alars search_and_track_auv_action --ros-args -p use_sim_time:=$USE_SIM_TIME -r __ns:=/$ROBOT_NAME" C-m
+tmux send-keys "echo 'This will be alars-localize'" C-m
 
 tmux select-pane -t $SESSION:1.2
-tmux send-keys "ros2 run alars rescuepoint_server --ros-args -p use_sim_time:=$USE_SIM_TIME -r __ns:=/$ROBOT_NAME" C-m
+tmux send-keys "echo 'This will be alars-recover'" C-m
+
+tmux select-pane -t $SESSION:1.3
+tmux send-keys "echo 'This will be alars-checkload'" C-m
+
 
 # bt
 tmux new-window -t $SESSION:2 -n 'BT'
@@ -114,46 +118,53 @@ tmux rename-window "BT"
 tmux select-window -t $SESSION:2
 tmux send-keys "ros2 launch wasp_bt wasp_bt.launch robot_name:=$ROBOT_NAME agent_type:=$AGENT_TYPE pulse_rate:=$PULSE_RATE use_sim_time:=$USE_SIM_TIME" C-m
 
+# move-to
+tmux new-window -t $SESSION:3 -n 'MoveTo'
+tmux rename-window "MoveTo"
+tmux select-window -t $SESSION:3
+tmux send-keys "ros2 launch go_to_geopoint go_to_geopoint_server.launch robot_name:=$ROBOT_NAME use_sim_time:=$USE_SIM_TIME setpoint_topic:=move_to_setpoint" C-m
+
+
+# camera and detection node
+tmux new-window -t $SESSION:4 -n 'Camera'
+tmux rename-window "Cam"
+tmux select-window -t $SESSION:4
+tmux split-window -h -t $SESSION:4.0
+tmux select-pane -t $SESSION:4.0
+tmux send-keys "echo 'This will be the sam/buoy detector node'" C-m
+
+# the cam driver is needed just for the real thing
+if [[ $USE_SIM_TIME = "False" ]]; then
+    tmux select-pane -t $SESSION:4.1
+    tmux send-keys "ros2 run usb_cam usb_cam_node_exe --ros-args -r __ns:=/$ROBOT_NAME/gimbal_camera" C-m
+fi
 
 
 # mqtt bridge
-tmux new-window -t $SESSION:3 -n 'MQTTBridge'
+tmux new-window -t $SESSION:8 -n 'MQTTBridge'
 tmux rename-window "MQTTBridge"
-tmux select-window -t $SESSION:3
+tmux select-window -t $SESSION:8
 tmux send-keys "ros2 launch str_json_mqtt_bridge waraps_bridge.launch robot_name:=$ROBOT_NAME domain:=air realsim:=$REALSIM broker_addr:=$MQTT_ADDR broker_port:=$MQTT_PORT context:=alars" C-m
 
 
 # only needed when running the sim
 if [[ $USE_SIM_TIME = "True" ]]; then
     # ROS2Bridge
-    tmux new-window -t $SESSION:4 -n 'SimConn'
-    tmux select-window -t $SESSION:4
+    tmux new-window -t $SESSION:9 -n 'SimConn'
+    tmux select-window -t $SESSION:9
     tmux send-keys "ros2 run ros_tcp_endpoint default_server_endpoint --ros-args -p tcp_ip:=localhost -p tcp_port:=10000" C-m
     if [[ $ON_LINUX = "True" ]]; then
         # mqtt broker
-        tmux split-window -h -t $SESSION:4.0
-        tmux select-pane -t $SESSION:4.1
+        tmux split-window -h -t $SESSION:9.0
+        tmux select-pane -t $SESSION:9.1
         tmux send-keys "mosquitto -p $MQTT_PORT" C-m
     fi
 fi
 
-# only launch if not the simulator
-# camera node
-if [[ $USE_SIM_TIME = "False" ]]; then
-    tmux new-window -t $SESSION:4 -n 'Cam'
-    tmux rename-window "Cam"
-    tmux select-window -t $SESSION:4
-    tmux split-window -h -t $SESSION:4.0
-    tmux select-pane -t $SESSION:4.0
-    tmux send-keys "ros2 run usb_cam usb_cam_node_exe --ros-args -r __ns:=/$ROBOT_NAME/gimbal_camera" C-m
-    tmux select-pane -t $SESSION:4.1
-    tmux send-keys "ros2 launch auv_detector estimator_detector_field_test.launch robot_name:=$ROBOT_NAME" C-m
-fi
-
-
-
-# Set default window
+# Set default window to either the captain 
+# or the psdk node depending on real/sim
+# both are on 0.0
 tmux select-window -t $SESSION:0
-tmux select-pane -t $SESSION:0.1
+tmux select-pane -t $SESSION:0.0
 # attach to the new session
 tmux -2 attach-session -t $SESSION

--- a/scripts/smarc_bringups/scripts/dji_bringup.sh
+++ b/scripts/smarc_bringups/scripts/dji_bringup.sh
@@ -46,15 +46,19 @@ if [ "$USE_SIM_TIME" = "False" ]; then
     tmux send-keys "ros2 run dji_captain dji_captain --ros-args -r __ns:=/$ROBOT_NAME" C-m
 
     tmux select-pane -t $SESSION:0.2
+    tmux send-keys "fast-discovery-server -i 0" C-m
+    
+    tmux select-pane -t $SESSION:0.3
     tmux send-keys "ros2 topic echo /$ROBOT_NAME/captain_status std_msgs/msg/String --field data" C-m
 
-    tmux select-pane -t $SESSION:0.3
-    # tmux send-keys "cd ~ && ./record_bag_ex_camComp.sh" C-m
-    tmux send-keys "fast-discovery-server -i 0" C-m
 else
     tmux select-window -t $SESSION:0
-    tmux select-pane -t $SESSION:0.1
+    tmux split-window -h -t $SESSION:0.0
+    tmux select-pane -t $SESSION:0.0
     tmux send-keys "ros2 run dji_captain dji_captain --ros-args -p use_sim_time:=$USE_SIM_TIME -r __ns:=/$ROBOT_NAME" C-m
+
+    tmux select-pane -t $SESSION:0.1
+    tmux send-keys "ros2 topic echo /$ROBOT_NAME/captain_status std_msgs/msg/String --field data" C-m
 fi
 
 

--- a/vehicles/hardware/dji/dji_captain/dji_captain/dji_captain.py
+++ b/vehicles/hardware/dji/dji_captain/dji_captain/dji_captain.py
@@ -73,12 +73,15 @@ class DjiCaptain():
         self._node.declare_parameter("robot_name", "M350")
         self._node.declare_parameter("controller_deadzone", 0.1)
         self._node.declare_parameter("controller_yawrate_multiplier", 0.3)
+        self._node.declare_parameter("home_altitude_above_water", 10.0)
 
         self.ROBOT_NAME : str = self._node.get_parameter("robot_name").get_parameter_value().string_value
         self._TF_NS : str = f"{self.ROBOT_NAME}/"
 
         self._CONTROLLER_DEADZONE : float = self._node.get_parameter("controller_deadzone").get_parameter_value().double_value
         self._CONTROLLER_YAWRATE_MULTIPLIER : float = self._node.get_parameter("controller_yawrate_multiplier").get_parameter_value().double_value
+        
+        self._HOME_ALT_ABOVE_WATER = self._node.get_parameter("home_altitude_above_water").get_parameter_value().double_value
 
         
         
@@ -1033,7 +1036,7 @@ class DjiCaptain():
             home_tf.child_frame_id = self.HOME_FRAME
             home_tf.transform.translation.x = self._home_point_in_utm.point.x 
             home_tf.transform.translation.y = self._home_point_in_utm.point.y
-            home_tf.transform.translation.z = self._home_point_in_utm.point.z 
+            home_tf.transform.translation.z = self._home_point_in_utm.point.z + self._HOME_ALT_ABOVE_WATER
             tf_msg.transforms.append(home_tf)
 
 
@@ -1110,6 +1113,8 @@ class DjiCaptain():
             tf_msg.transforms.append(move_to_setpoint_tf)
 
         self._tf_pub.publish(tf_msg) 
+
+
     def _publish_smarc(self):
         if self._base_pose_in_home is None or self._home_point_in_utm is None or self._gps_point_in_home is None:
             return

--- a/vehicles/hardware/dji/dji_captain/dji_captain/dji_captain.py
+++ b/vehicles/hardware/dji/dji_captain/dji_captain/dji_captain.py
@@ -354,17 +354,13 @@ class DjiCaptain():
         s = "\nDjiCaptain Status:\n"
         s += f"  UTM Frame: {self._utm_labeled_frame}\n"
         s += f"  Home in UTM: {format_point_stamped(self._home_point_in_utm)}\n"
-        s += f"  GPS in Home: {format_point_stamped(self._gps_point_in_home)}\n"
-        s += f"  RTK in Home: {format_point_stamped(self._rtk_point_in_home)}\n"
 
         s += f"\n  Position in Home: {format_pose_stamped(self._base_pose_in_home)}\n"
-        s += f"  Velocity Ground: {format_vector3_stamped(self._velocity_ground)}\n"
-        s += f"  Angular Rate Ground: {format_vector3_stamped(self._angular_rate_ground)}\n"
-        s += f"  Geo Altitude: {self._geo_altitude}\n"
-        s += f"  Home Geo Altitude: {self._home_geo_altitude}\n"
         s += f"  Heading: {self._heading_deg}\n"
         s += f"  Course: {self._course_deg}\n"
         s += f"  Battery Percent: {self._battery_percent} (ready:{self.READY_BATTERY_PERCENTAGE}, error:{self.ERROR_BATTERY_PERCENTAGE})\n"
+        s += f"  Velocity Ground: {format_vector3_stamped(self._velocity_ground)}\n"
+        s += f"  Angular Rate Ground: {format_vector3_stamped(self._angular_rate_ground)}\n"
         
         s += f"\n  Smarc Topics: {self._smarc_pub_status}\n"
         s += f"  TF: {self._tf_pub_status}\n"
@@ -668,7 +664,6 @@ class DjiCaptain():
 
         if (self._prev_joy_output is None):
             self._prev_joy_output = np.array([FLU_vel.pose.position.x, FLU_vel.pose.position.y, FLU_vel.pose.position.z])
-            #TODO DJURO FRIDAY test this with 0s.
 
         try:
             tf_diff = self._tf_buffer.lookup_transform(

--- a/vehicles/hardware/dji/dji_captain/dji_captain/dji_captain.py
+++ b/vehicles/hardware/dji/dji_captain/dji_captain/dji_captain.py
@@ -73,7 +73,9 @@ class DjiCaptain():
         self._node.declare_parameter("robot_name", "M350")
         self._node.declare_parameter("controller_deadzone", 0.1)
         self._node.declare_parameter("controller_yawrate_multiplier", 0.3)
-        self._node.declare_parameter("home_altitude_above_water", 10.0)
+        # give an error-causing default value to force the user to pass this parameter every time
+        # there is no safe assumption that can be made for this.
+        self._node.declare_parameter("home_altitude_above_water", -1.0)
 
         self.ROBOT_NAME : str = self._node.get_parameter("robot_name").get_parameter_value().string_value
         self._TF_NS : str = f"{self.ROBOT_NAME}/"
@@ -82,6 +84,12 @@ class DjiCaptain():
         self._CONTROLLER_YAWRATE_MULTIPLIER : float = self._node.get_parameter("controller_yawrate_multiplier").get_parameter_value().double_value
         
         self._HOME_ALT_ABOVE_WATER = self._node.get_parameter("home_altitude_above_water").get_parameter_value().double_value
+
+        if self._HOME_ALT_ABOVE_WATER <= 0:
+            self.log("Warning: home_altitude_above_water parameter not set or invalid! It is {self._HOME_ALT_ABOVE_WATER}")
+            self.log("YOU MUST PASS THIS PARAMETER AND MAKE SURE IT IS CORRECT!")
+            self.log("Captain will not run. Exiting.")
+            sys.exit(1)
 
         
         
@@ -364,11 +372,8 @@ class DjiCaptain():
         s += f"\n  Got Control: {self._got_control}\n"
         s += f"  Control Mode: {self._control_mode.value}\n"
         s += f"  Current target setpoint: {format_pose_stamped(self._move_to_setpoint)}\n"
-        if self._base_pose_in_home is None: 
-            s+= "  Flying: Unknown (base pose not set)\n"
-        else:
-            s += f"  Flying: {self._flying} ({self._base_pose_in_home.pose.position.z:.3f} >? {self.READY_HEIGHT_ABOVE_GROUND})\n"
-        # s += f"  Carrying Payload: {self._carrying_payload}\n"
+        s += f"  Flying: {self._flying}\n"
+
         if self._vehicle_health.data == SmarcTopics.VEHICLE_HEALTH_READY:
             s += f"  Vehicle Health: READY\n"
         elif self._vehicle_health.data == SmarcTopics.VEHICLE_HEALTH_ERROR:
@@ -648,11 +653,13 @@ class DjiCaptain():
             self._move_to_setpoint = None
             self._cancel_joy_timer()
             return
+        
         tf = self._tf_buffer.lookup_transform(
             target_frame = self.BASE_FLAT_FRAME,
             source_frame = self._velocity_ground.header.frame_id,
             time=Time(seconds=0),
             timeout=Duration(seconds=1))
+        
         vel_pose = PoseStamped()
         vel_pose.pose.position.x = self._velocity_ground.vector.x
         vel_pose.pose.position.y = self._velocity_ground.vector.y
@@ -661,6 +668,7 @@ class DjiCaptain():
 
         if (self._prev_joy_output is None):
             self._prev_joy_output = np.array([FLU_vel.pose.position.x, FLU_vel.pose.position.y, FLU_vel.pose.position.z])
+            #TODO DJURO FRIDAY test this with 0s.
 
         try:
             tf_diff = self._tf_buffer.lookup_transform(
@@ -733,6 +741,7 @@ class DjiCaptain():
             self.log("Not got control, cannot move with joy.")
             self._cancel_joy_timer()
             return
+        
         try:
             tf_diff = self._tf_buffer.lookup_transform(
                 target_frame = self.BASE_ENU_FRAME, #This is the frame centered on the baselink but locked to ENU rotationally
@@ -780,6 +789,7 @@ class DjiCaptain():
 
         if msg.axes[0] != 0.0 or msg.axes[1] != 0.0 or msg.axes[2] != 0.0 or msg.axes[3] != 0.0:
             self.log("RC touched, giving up control.")
+            self._got_control = False # even if the service call fails, we assume we lost control!
             self._release_control_srv.call_async(Trigger.Request()).add_done_callback(
                 lambda future: self.log(f"Release control service called, success: {future.result().success}, message: {future.result().message}")
             )
@@ -908,7 +918,11 @@ class DjiCaptain():
 
         self._home_point_in_utm.point.x = utm.point.x
         self._home_point_in_utm.point.y = utm.point.y
-        self._home_point_in_utm.point.z = 0.0
+        # we set the altitude of home point to a constant above water level
+        # since almost everything we do is relative to the water level, and not geographical altitude
+        # in sim, we can _know_ this altitude, but in real life we can't, so we take it as a param from
+        # the user. 
+        self._home_point_in_utm.point.z = self._HOME_ALT_ABOVE_WATER
         self._home_point_in_utm.header.stamp = self.now_stamp
 
     def _home_point_altitude_callback(self, msg: Float32):
@@ -971,20 +985,18 @@ class DjiCaptain():
         position_ok = self._home_point_in_utm is not None and self._base_pose_in_home is not None
         gps_ok = self._gps_point_in_home is not None and self._home_point_in_utm is not None
         battery_ok = self._battery_percent is not None and self._battery_percent > self.READY_BATTERY_PERCENTAGE
-        height_ok = self._base_pose_in_home.pose.position.z > self.READY_HEIGHT_ABOVE_GROUND
         control_ok = self._got_control
 
-        if all([position_ok, gps_ok, battery_ok, height_ok, control_ok]):
+        if all([position_ok, gps_ok, battery_ok, control_ok]):
             self._vehicle_health.data = SmarcTopics.VEHICLE_HEALTH_READY
 
 
         # collect all the rpms and currents into lists
-        #TODO use the currents/speed to determine if we are carrying a payload eventually.
         speeds = [esc.speed for esc in list(self._esc_data.esc)[:self.NUM_PROPS]]
         # currents = [esc.current for esc in list(self._esc_data.esc)[:self.NUM_PROPS]]
         # check if all of the rpms are above the idle rpm
-        speeds_flying = all(rpm > self.ESC_IDLE_RPM for rpm in speeds)
-        self._flying = speeds_flying and height_ok
+        # we cant check position above home, because it is very possible that we launched high and flew down...
+        self._flying = all(rpm > self.ESC_IDLE_RPM for rpm in speeds)
 
 
 
@@ -1036,7 +1048,7 @@ class DjiCaptain():
             home_tf.child_frame_id = self.HOME_FRAME
             home_tf.transform.translation.x = self._home_point_in_utm.point.x 
             home_tf.transform.translation.y = self._home_point_in_utm.point.y
-            home_tf.transform.translation.z = self._home_point_in_utm.point.z + self._HOME_ALT_ABOVE_WATER
+            home_tf.transform.translation.z = self._home_point_in_utm.point.z
             tf_msg.transforms.append(home_tf)
 
 
@@ -1153,9 +1165,14 @@ class DjiCaptain():
         base_in_utm.point.x = self._base_pose_in_home.pose.position.x + self._home_point_in_utm.point.x
         base_in_utm.point.y = self._base_pose_in_home.pose.position.y + self._home_point_in_utm.point.y
         base_in_geopoint = convert_utm_to_latlon(base_in_utm)
-        base_in_geopoint.altitude = self._base_pose_in_home.pose.position.z
+        
+        # this is specific to smarc, since we take the water level as basis for everything
+        alt_above_water = self._HOME_ALT_ABOVE_WATER + self._base_pose_in_home.pose.position.z
+
+        base_in_geopoint.altitude = alt_above_water
         self._pos_latlon_pub.publish(base_in_geopoint)
-        self._altitude_pub.publish(Float32(data=self._base_pose_in_home.pose.position.z))
+
+        self._altitude_pub.publish(Float32(data = alt_above_water))
 
 
         if self._heading_deg is not None:


### PR DESCRIPTION
Lots of QoL improvements to make it easier to run both the real drone and the sim drone.

The captain now _requires_ a given altitude-above-water parameter. This is given to dji_bringup as the first arg. This is a critical value that needs to be somewhat accurate, since the "altitude" of the drone will be calculated wrt to this. 0 altitude is water-level. 

In sim, you should pass the y value of the M350 prefab.
In real life, you should measure where the drone is sitting wrt to water and pass that. 

dji_bringup now launches moquitto on localhost:1889 and the unity ros bridge if you are running it on Linux, and not on the real drone. Thus, the steps for testing/running the whole DJI setup is thus:
- `ros2 run smarc_bringups dji_bringup <HOME-ALT-ABOVE-WATER>`
- Run sim
- Connect to ROS
- Connect to MQTT
- On the captain node, take control, then take off (press enter if you dont see the menu)
- You can now start sending the captain points to move the drone towards.