### PR TITLE
smarc_action_base_cpp

### DIFF
--- a/behaviours/smarc/smarc_action_base_cpp/CMakeLists.txt
+++ b/behaviours/smarc/smarc_action_base_cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(smarc_msgs REQUIRED)
 find_package(nlohmann_json REQUIRED)
 
 add_library(gentler_action_server
+  src/graceful_shutdown.cpp
   src/gentler_action_server.cpp
 )
 target_include_directories(gentler_action_server PUBLIC

--- a/behaviours/smarc/smarc_action_base_cpp/CMakeLists.txt
+++ b/behaviours/smarc/smarc_action_base_cpp/CMakeLists.txt
@@ -1,0 +1,80 @@
+cmake_minimum_required(VERSION 3.8)
+project(smarc_action_base_cpp)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(smarc_msgs REQUIRED)
+find_package(nlohmann_json REQUIRED)
+
+add_library(gentler_action_server
+  src/gentler_action_server.cpp
+)
+target_include_directories(gentler_action_server PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+ament_target_dependencies(gentler_action_server
+  rclcpp
+  rclcpp_action
+  std_msgs
+  smarc_msgs
+)
+target_link_libraries(gentler_action_server
+  nlohmann_json::nlohmann_json
+)
+
+add_executable(super_simple_action_server_cpp
+  src/super_simple_action_server.cpp
+)
+target_include_directories(super_simple_action_server_cpp PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
+ament_target_dependencies(super_simple_action_server_cpp
+  rclcpp
+)
+target_link_libraries(super_simple_action_server_cpp
+  gentler_action_server
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS gentler_action_server
+  EXPORT export_gentler_action_server
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(
+  TARGETS super_simple_action_server_cpp
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_export_targets(export_gentler_action_server HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  rclcpp
+  rclcpp_action
+  std_msgs
+  smarc_msgs
+  nlohmann_json
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/behaviours/smarc/smarc_action_base_cpp/README.md
+++ b/behaviours/smarc/smarc_action_base_cpp/README.md
@@ -1,0 +1,99 @@
+# smarc_action_base_cpp
+# How do I use this?
+
+That question is better answered by `src/super_simple_action_server.cpp` than in this README. Unless you intend to make additions to the C++ action server helpers it is recommended to review the implementation shown there to understand how to use `smarc_action_base_cpp`.
+
+# Library that enforces ROS2 action-server interfaces be implemented using a C++ GentlerActionServer.
+The library intends to abstract and simplify the registering of callbacks and hide some of the async complexity from the user.
+
+The C++ API mirrors the Python `GentlerActionServer` pattern:
+
+```cpp
+GentlerActionServer(
+  node,
+  "my_action_name",
+  on_goal_received,
+  on_cancel_received,
+  prepare_loop,
+  loop_inner,
+  give_feedback,
+  GentlerActionServer::Config(5.0));
+```
+
+## Abstractions
+### GentlerActionServer
+This is a simple wrapper around `smarc_msgs::action::BaseAction`. It accepts the same JSON-in-a-string goal format used by the Python behaviours, calls user-provided callbacks, publishes feedback, and reports success or failure.
+
+The user-provided callbacks are:
+
+```cpp
+bool on_goal_received(const nlohmann::json & goal);
+bool on_cancel_received();
+void prepare_loop();
+GentlerActionServer::LoopStatus loop_inner();
+std::string give_feedback();
+```
+
+`LoopStatus` replaces the Python `True`, `False`, and `None` convention:
+
+```cpp
+LoopStatus::SUCCESS
+LoopStatus::FAILURE
+LoopStatus::RUNNING
+```
+
+Additionally, the action server publishes the WARA-PS heartbeat so the action can be discovered in the same way as the Python action servers.
+
+### Graceful Shutdown
+Action servers need a little ceremony when the server process is stopped while a goal is active. The helper in `graceful_shutdown.hpp` keeps ROS alive long enough to abort the active goal, flush the terminal action state, and then call `rclcpp::shutdown()`.
+
+This is the recommended shape:
+
+```cpp
+auto init_options = smarc_action_base_cpp::manual_signal_handling_init_options();
+rclcpp::init(argc, argv, init_options);
+smarc_action_base_cpp::install_signal_handlers();
+
+...
+
+smarc_action_base_cpp::spin_with_graceful_shutdown(
+    executor, [&action]() { action->request_shutdown(); });
+```
+
+## Method
+Callback functions are wrapped in a simplified pattern preventing user callbacks from being called directly by ROS2 action plumbing. Instead they are called through `GentlerActionServer`, which parses the JSON goal, manages the active goal handle, publishes feedback, and translates `LoopStatus` into ROS2 action terminal states.
+
+Example of this is shown below:
+
+```cpp
+LoopStatus loop_inner()
+{
+  ++looped_for_;
+  if (looped_for_ >= loop_max_) {
+    return LoopStatus::SUCCESS;
+  }
+  return LoopStatus::RUNNING;
+}
+```
+
+Additionally the C++ action server owns its execution thread and exposes `request_shutdown()` so executables can abort an active goal cleanly before shutting the ROS context down.
+
+When necessary values are extracted and saved in private variables to store for usage later which may require duplicate checking of values and conditionals. An example of this is extracting a value from the JSON goal before the loop starts:
+
+```cpp
+bool on_goal_received(const Json & goal)
+{
+  loop_max_ = goal.value("loop_max", 25);
+  return loop_max_ > 0;
+}
+```
+
+# Useful Docs
+
+These examples are very useful in seeing how ROS recommends doing this stuff.
+- [Link for Action Client Examples](https://github.com/ros2/examples/tree/master/rclcpp/actions/minimal_action_client)
+- [Link for Action Server Examples](https://github.com/ros2/examples/tree/humble/rclcpp/actions/minimal_action_server)
+
+CancelGoal Relevant Docs:
+
+- [CancelGoal Underlying Message](https://docs.ros2.org/foxy/api/action_msgs/srv/CancelGoal.html)

--- a/behaviours/smarc/smarc_action_base_cpp/include/smarc_action_base_cpp/gentler_action_server.hpp
+++ b/behaviours/smarc/smarc_action_base_cpp/include/smarc_action_base_cpp/gentler_action_server.hpp
@@ -8,6 +8,7 @@
 #ifndef SMARC_ACTION_BASE_CPP__GENTLER_ACTION_SERVER_HPP_
 #define SMARC_ACTION_BASE_CPP__GENTLER_ACTION_SERVER_HPP_
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -73,6 +74,7 @@ class GentlerActionServer {
 
   std::string action_name() const;
   std::string parsed_action_name() const;
+  void request_shutdown();
 
  private:
   rclcpp_action::GoalResponse handle_goal(
@@ -106,6 +108,7 @@ class GentlerActionServer {
   rclcpp::TimerBase::SharedPtr heartbeat_timer_;
 
   // For the plumbing and bookkeeping done in the SMARCActionServer.
+  std::atomic_bool stop_requested_{false};
   mutable std::mutex goal_mutex_;
   std::shared_ptr<GoalHandle> active_goal_handle_;
   std::thread execution_thread_;

--- a/behaviours/smarc/smarc_action_base_cpp/include/smarc_action_base_cpp/gentler_action_server.hpp
+++ b/behaviours/smarc/smarc_action_base_cpp/include/smarc_action_base_cpp/gentler_action_server.hpp
@@ -1,0 +1,116 @@
+/* file: gentler_action_server.hpp
+ * description: Pretty much a 1:1 translation of Ozer's GentlerActionServer from
+ * python to cpp. We do not inherit from the SMARCActionServer, but instead
+ * embedd the plumbing (and heartbeat-publishing) in a single cpp class, and use
+ * the same API as its python counterpart to make sure it's compatible with
+ * our behaviour tree.
+ */
+#ifndef SMARC_ACTION_BASE_CPP__GENTLER_ACTION_SERVER_HPP_
+#define SMARC_ACTION_BASE_CPP__GENTLER_ACTION_SERVER_HPP_
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+#include "smarc_msgs/action/base_action.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace smarc_action_base_cpp {
+
+class GentlerActionServer {
+ public:
+  using BaseAction = smarc_msgs::action::BaseAction;
+  using GoalHandle = rclcpp_action::ServerGoalHandle<BaseAction>;
+  using Json = nlohmann::json;
+
+  enum class LoopStatus { RUNNING, SUCCESS, FAILURE };
+
+  struct Config {
+    explicit Config(double loop_frequency_hz = 5.0,
+                    double heartbeat_period_s = 1.0,
+                    std::string heartbeat_topic =
+                        "waraps/action_server_heartbeat",
+                    bool preempt_active_goal = true)
+        : loop_frequency_hz(loop_frequency_hz),
+          heartbeat_period_s(heartbeat_period_s),
+          heartbeat_topic(std::move(heartbeat_topic)),
+          preempt_active_goal(preempt_active_goal) {}
+
+    double loop_frequency_hz;
+    double heartbeat_period_s;
+    std::string heartbeat_topic;
+    bool preempt_active_goal;
+  };
+
+  using OnGoalReceived = std::function<bool(const Json &)>;
+  using OnCancelReceived = std::function<bool()>;
+  using PrepareLoop = std::function<void()>;
+  using LoopInner = std::function<LoopStatus()>;
+  using GiveFeedback = std::function<std::string()>;
+
+  GentlerActionServer(rclcpp::Node::SharedPtr node,
+                      const std::string &action_name,
+                      OnGoalReceived on_goal_received,
+                      OnCancelReceived on_cancel_received,
+                      PrepareLoop prepare_loop, LoopInner loop_inner,
+                      GiveFeedback give_feedback,
+                      const Config &config = Config{});
+
+  ~GentlerActionServer();
+
+  // Copy and move guards.
+  GentlerActionServer(const GentlerActionServer &) = delete;
+  GentlerActionServer &operator=(const GentlerActionServer &) = delete;
+  GentlerActionServer(GentlerActionServer &&) = delete;
+  GentlerActionServer &operator=(GentlerActionServer &&) = delete;
+
+  std::string action_name() const;
+  std::string parsed_action_name() const;
+
+ private:
+  rclcpp_action::GoalResponse handle_goal(
+      const rclcpp_action::GoalUUID &uuid,
+      std::shared_ptr<const BaseAction::Goal> goal);
+
+  rclcpp_action::CancelResponse handle_cancel(
+      const std::shared_ptr<GoalHandle> goal_handle);
+
+  void handle_accepted(const std::shared_ptr<GoalHandle> goal_handle);
+  void execute(const std::shared_ptr<GoalHandle> goal_handle);
+  // For WARA-PS BT compliance.
+  void publish_heartbeat();
+
+  std::string construct_parsed_action_name() const;
+  void stop_execution_thread();
+
+  rclcpp::Node::SharedPtr node_;
+  std::string action_name_;
+  std::string parsed_action_name_;
+  Config config_;
+
+  OnGoalReceived on_goal_received_;
+  OnCancelReceived on_cancel_received_;
+  PrepareLoop prepare_loop_;
+  LoopInner loop_inner_;
+  GiveFeedback give_feedback_;
+
+  rclcpp_action::Server<BaseAction>::SharedPtr action_server_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr heartbeat_pub_;
+  rclcpp::TimerBase::SharedPtr heartbeat_timer_;
+
+  // For the plumbing and bookkeeping done in the SMARCActionServer.
+  mutable std::mutex goal_mutex_;
+  std::shared_ptr<GoalHandle> active_goal_handle_;
+  std::thread execution_thread_;
+};
+
+}  // namespace smarc_action_base_cpp
+
+#endif  // SMARC_ACTION_BASE_CPP__GENTLER_ACTION_SERVER_HPP_

--- a/behaviours/smarc/smarc_action_base_cpp/include/smarc_action_base_cpp/graceful_shutdown.hpp
+++ b/behaviours/smarc/smarc_action_base_cpp/include/smarc_action_base_cpp/graceful_shutdown.hpp
@@ -1,0 +1,44 @@
+/* file: graceful_shutdown.hpp
+ * description: These are helper functions that allow us to take control of the
+ * shutdown sequence for action servers developed with the GentlerActionServer 
+ * in c++. Using ROS' shutdown lead to action clients hanging while canceling a
+ * goal if the action server had crashed or was shutdown for any reason before
+ * resolving a client's goal. The gist is the following:
+ *  - catch SIGINT and SIGTERM signals.
+ *  - trigger a flag for shutdown.
+ *  - stop spinning the exec and exit the while rclcpp::ok loop.
+ *  - send an ABORT to the client.
+ *  - spin a bit more to make sure the client gets the abort.
+ *  - shutdown gracefully.
+ */
+#ifndef SMARC_ACTION_BASE_CPP__GRACEFUL_SHUTDOWN_HPP_
+#define SMARC_ACTION_BASE_CPP__GRACEFUL_SHUTDOWN_HPP_
+
+#include <chrono>
+#include <functional>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace smarc_action_base_cpp {
+
+using ShutdownCallback = std::function<void()>;
+
+rclcpp::InitOptions manual_signal_handling_init_options();
+void install_signal_handlers();
+void reset_signal_shutdown_request();
+bool signal_shutdown_requested();
+
+void spin_some_for(
+    rclcpp::Executor &executor,
+    std::chrono::milliseconds duration,
+    std::chrono::milliseconds spin_period = std::chrono::milliseconds(100));
+
+void spin_with_graceful_shutdown(
+    rclcpp::Executor &executor,
+    const ShutdownCallback &on_shutdown,
+    std::chrono::milliseconds spin_period = std::chrono::milliseconds(100),
+    std::chrono::milliseconds flush_duration = std::chrono::milliseconds(500));
+
+}  // namespace smarc_action_base_cpp
+
+#endif  // SMARC_ACTION_BASE_CPP__GRACEFUL_SHUTDOWN_HPP_

--- a/behaviours/smarc/smarc_action_base_cpp/package.xml
+++ b/behaviours/smarc/smarc_action_base_cpp/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>smarc_action_base_cpp</name>
+  <version>0.0.0</version>
+  <description>C++ action server helpers for SMARC behaviours.</description>
+  <maintainer email="aldot@kth.se">aldo</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>std_msgs</depend>
+  <depend>smarc_msgs</depend>
+  <depend>nlohmann_json</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/behaviours/smarc/smarc_action_base_cpp/package.xml
+++ b/behaviours/smarc/smarc_action_base_cpp/package.xml
@@ -13,7 +13,7 @@
   <depend>rclcpp_action</depend>
   <depend>std_msgs</depend>
   <depend>smarc_msgs</depend>
-  <depend>nlohmann-json3-dev</depend>
+  <depend>nlohmann-json-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/behaviours/smarc/smarc_action_base_cpp/package.xml
+++ b/behaviours/smarc/smarc_action_base_cpp/package.xml
@@ -13,7 +13,7 @@
   <depend>rclcpp_action</depend>
   <depend>std_msgs</depend>
   <depend>smarc_msgs</depend>
-  <depend>nlohmann_json</depend>
+  <depend>nlohmann-json3-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/behaviours/smarc/smarc_action_base_cpp/src/gentler_action_server.cpp
+++ b/behaviours/smarc/smarc_action_base_cpp/src/gentler_action_server.cpp
@@ -1,0 +1,261 @@
+#include "smarc_action_base_cpp/gentler_action_server.hpp"
+
+#include <chrono>
+#include <exception>
+#include <utility>
+
+namespace smarc_action_base_cpp {
+
+GentlerActionServer::GentlerActionServer(
+    rclcpp::Node::SharedPtr node, const std::string &action_name,
+    OnGoalReceived on_goal_received, OnCancelReceived on_cancel_received,
+    PrepareLoop prepare_loop, LoopInner loop_inner, GiveFeedback give_feedback,
+    const Config &config)
+    : node_(std::move(node)),
+      action_name_(action_name),
+      config_(config),
+      on_goal_received_(std::move(on_goal_received)),
+      on_cancel_received_(std::move(on_cancel_received)),
+      prepare_loop_(std::move(prepare_loop)),
+      loop_inner_(std::move(loop_inner)),
+      give_feedback_(std::move(give_feedback)) {
+  parsed_action_name_ = construct_parsed_action_name();
+
+  // TODO: how do we get the heartbeat_topic from SmarcTopics?
+  heartbeat_pub_ = node_->create_publisher<std_msgs::msg::String>(
+      config_.heartbeat_topic, 5);
+  heartbeat_timer_ = node_->create_wall_timer(
+      std::chrono::duration<double>(config_.heartbeat_period_s),
+      std::bind(&GentlerActionServer::publish_heartbeat, this));
+
+  action_server_ = rclcpp_action::create_server<BaseAction>(
+      node_, action_name_,
+      std::bind(&GentlerActionServer::handle_goal, this, std::placeholders::_1,
+                std::placeholders::_2),
+      std::bind(&GentlerActionServer::handle_cancel, this,
+                std::placeholders::_1),
+      std::bind(&GentlerActionServer::handle_accepted, this,
+                std::placeholders::_1));
+}
+
+GentlerActionServer::~GentlerActionServer() {
+  {
+    // Lock the goal handle so that other threads don't tap into it since we're
+    // killing the instance.
+    std::lock_guard<std::mutex> lock(goal_mutex_);
+    active_goal_handle_.reset();
+  }
+  stop_execution_thread();
+}
+
+std::string GentlerActionServer::action_name() const { return action_name_; }
+
+std::string GentlerActionServer::parsed_action_name() const {
+  return parsed_action_name_;
+}
+
+rclcpp_action::GoalResponse GentlerActionServer::handle_goal(
+    const rclcpp_action::GoalUUID &uuid,
+    std::shared_ptr<const BaseAction::Goal> goal) {
+  (void)uuid;
+
+  // Preemtive check.
+  if (!config_.preempt_active_goal) {
+    std::lock_guard<std::mutex> lock(goal_mutex_);
+    if (active_goal_handle_ && active_goal_handle_->is_active()) {
+      RCLCPP_WARN(node_->get_logger(),
+                  "Rejecting goal for <%s>; another goal is active.",
+                  action_name_.c_str());
+      return rclcpp_action::GoalResponse::REJECT;
+    }
+  }
+
+  // Null goal pointer check.
+  if (!goal) {
+    RCLCPP_ERROR(node_->get_logger(), "Rejecting null goal for <%s>.",
+                 action_name_.c_str());
+    return rclcpp_action::GoalResponse::REJECT;
+  }
+
+  // Goal JSON check.
+  try {
+    const auto goal_json = Json::parse(goal->goal.data);
+    // Using user-provided OnGoalReceived function.
+    if (on_goal_received_(goal_json)) {
+      return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+    }
+
+    RCLCPP_INFO(node_->get_logger(), "User callback rejected goal for <%s>.",
+                action_name_.c_str());
+  } catch (const Json::parse_error &error) {
+    RCLCPP_ERROR(node_->get_logger(),
+                 "Rejecting goal for <%s>; JSON parse error: %s",
+                 action_name_.c_str(), error.what());
+  } catch (const std::exception &error) {
+    RCLCPP_ERROR(node_->get_logger(),
+                 "Rejecting goal for <%s>; callback threw: %s",
+                 action_name_.c_str(), error.what());
+  } catch (...) {
+    RCLCPP_ERROR(node_->get_logger(),
+                 "Rejecting goal for <%s>; callback threw unknown exception.",
+                 action_name_.c_str());
+  }
+
+  return rclcpp_action::GoalResponse::REJECT;
+}
+
+rclcpp_action::CancelResponse GentlerActionServer::handle_cancel(
+    const std::shared_ptr<GoalHandle> goal_handle) {
+  (void)goal_handle;
+
+  try {
+    // Using user-provided OnCancelReceived function.
+    return on_cancel_received_() ? rclcpp_action::CancelResponse::ACCEPT
+                                 : rclcpp_action::CancelResponse::REJECT;
+  } catch (const std::exception &error) {
+    RCLCPP_ERROR(node_->get_logger(),
+                 "Rejecting cancel for <%s>; callback threw: %s",
+                 action_name_.c_str(), error.what());
+  } catch (...) {
+    RCLCPP_ERROR(node_->get_logger(),
+                 "Rejecting cancel for <%s>; callback threw unknown exception.",
+                 action_name_.c_str());
+  }
+
+  return rclcpp_action::CancelResponse::REJECT;
+}
+
+void GentlerActionServer::handle_accepted(
+    const std::shared_ptr<GoalHandle> goal_handle) {
+  {
+    std::lock_guard<std::mutex> lock(goal_mutex_);
+    active_goal_handle_ = goal_handle;
+  }
+
+  // TODO: This might block if a running inner_loop with a prior goal does not
+  // exit preemtively, but still gives us clear lifetime management (in 
+  // comparison with the tutorial's implementation).
+  stop_execution_thread();
+  execution_thread_ =
+      std::thread(&GentlerActionServer::execute, this, goal_handle);
+}
+
+/* This is where the magic happens. We're locking the goal_mutex everytime we 
+ * need to read/compare/reset the active_goal_handle to ensure that no other
+ * thread is sweeping the rug underneath us. The logic below follows:
+ *  1. Check if the goal was preempted.
+ *  2. Check if the goal was canceled.
+ * if the above passed, then we run the user-defined InnerLoop:
+ *  3. If the loop_status says the loop is running, then business as usual and
+ *     continue (while).
+ *  4. If the loop_status says that we've succeeded, report whether the goal was
+ *     accomplished or not, reset the goal, and return.
+ */
+void GentlerActionServer::execute(
+    const std::shared_ptr<GoalHandle> goal_handle) {
+  auto result = std::make_shared<BaseAction::Result>();
+
+  try {
+    // User-specified PrepareLoop.
+    prepare_loop_();
+
+    rclcpp::Rate rate(config_.loop_frequency_hz);
+
+    while (rclcpp::ok()) {
+      {
+        std::lock_guard<std::mutex> lock(goal_mutex_);
+        if (active_goal_handle_ != goal_handle) {
+          result->success = false;
+          if (goal_handle->is_active()) {
+            goal_handle->abort(result);
+          }
+          RCLCPP_INFO(node_->get_logger(), "Goal for <%s> was preempted.",
+                      action_name_.c_str());
+          return;
+        }
+      }
+
+      if (goal_handle->is_canceling()) {
+        result->success = false;
+        goal_handle->canceled(result);
+        {
+          std::lock_guard<std::mutex> lock(goal_mutex_);
+          if (active_goal_handle_ == goal_handle) {
+            active_goal_handle_.reset();
+          }
+        }
+        RCLCPP_INFO(node_->get_logger(), "Goal for <%s> was canceled.",
+                    action_name_.c_str());
+        return;
+      }
+
+      // If no need to tamper with the goal, run the user-specified InnerLoop.
+      const auto loop_status = loop_inner_();
+      if (loop_status == LoopStatus::RUNNING) {
+        auto feedback = std::make_shared<BaseAction::Feedback>();
+        feedback->feedback.data = give_feedback_();
+        goal_handle->publish_feedback(feedback);
+        rate.sleep();
+        continue;
+      }
+
+      result->success = loop_status == LoopStatus::SUCCESS;
+      if (result->success) {
+        goal_handle->succeed(result);
+        RCLCPP_INFO(node_->get_logger(), "Goal for <%s> succeeded.",
+                    action_name_.c_str());
+      } else {
+        goal_handle->abort(result);
+        RCLCPP_INFO(node_->get_logger(), "Goal for <%s> failed.",
+                    action_name_.c_str());
+      }
+      {
+        std::lock_guard<std::mutex> lock(goal_mutex_);
+        if (active_goal_handle_ == goal_handle) {
+          active_goal_handle_.reset();
+        }
+      }
+      return;
+    }
+  } catch (const std::exception &error) {
+    RCLCPP_ERROR(node_->get_logger(), "Goal for <%s> aborted; exception: %s",
+                 action_name_.c_str(), error.what());
+  } catch (...) {
+    RCLCPP_ERROR(node_->get_logger(),
+                 "Goal for <%s> aborted; unknown exception.",
+                 action_name_.c_str());
+  }
+
+  result->success = false;
+  if (goal_handle->is_active()) {
+    goal_handle->abort(result);
+  }
+  {
+    std::lock_guard<std::mutex> lock(goal_mutex_);
+    if (active_goal_handle_ == goal_handle) {
+      active_goal_handle_.reset();
+    }
+  }
+}
+
+void GentlerActionServer::publish_heartbeat() {
+  std_msgs::msg::String msg;
+  msg.data = parsed_action_name_;
+  heartbeat_pub_->publish(msg);
+}
+
+std::string GentlerActionServer::construct_parsed_action_name() const {
+  std::string ns = node_->get_namespace();
+  if (ns == "/") {
+    ns.clear();
+  }
+  return ns + "/" + action_name_;
+}
+
+void GentlerActionServer::stop_execution_thread() {
+  if (execution_thread_.joinable()) {
+    execution_thread_.join();
+  }
+}
+
+}  // namespace smarc_action_base_cpp

--- a/behaviours/smarc/smarc_action_base_cpp/src/gentler_action_server.cpp
+++ b/behaviours/smarc/smarc_action_base_cpp/src/gentler_action_server.cpp
@@ -38,15 +38,7 @@ GentlerActionServer::GentlerActionServer(
                 std::placeholders::_1));
 }
 
-GentlerActionServer::~GentlerActionServer() {
-  {
-    // Lock the goal handle so that other threads don't tap into it since we're
-    // killing the instance.
-    std::lock_guard<std::mutex> lock(goal_mutex_);
-    active_goal_handle_.reset();
-  }
-  stop_execution_thread();
-}
+GentlerActionServer::~GentlerActionServer() { request_shutdown(); }
 
 std::string GentlerActionServer::action_name() const { return action_name_; }
 
@@ -54,10 +46,46 @@ std::string GentlerActionServer::parsed_action_name() const {
   return parsed_action_name_;
 }
 
+void GentlerActionServer::request_shutdown() {
+  stop_requested_.store(true);
+
+  if (heartbeat_timer_) {
+    heartbeat_timer_->cancel();
+  }
+
+  std::shared_ptr<GoalHandle> goal_handle;
+  {
+    std::lock_guard<std::mutex> lock(goal_mutex_);
+    goal_handle = active_goal_handle_;
+    active_goal_handle_.reset();
+  }
+
+  if (goal_handle && goal_handle->is_active() && rclcpp::ok()) {
+    auto result = std::make_shared<BaseAction::Result>();
+    result->success = false;
+    try {
+      goal_handle->abort(result);
+      RCLCPP_INFO(node_->get_logger(),
+                  "Goal for <%s> aborted due to server shutdown.",
+                  action_name_.c_str());
+    } catch (const std::exception &error) {
+      RCLCPP_WARN(node_->get_logger(),
+                  "Could not abort goal for <%s> during shutdown: %s",
+                  action_name_.c_str(), error.what());
+    }
+  }
+
+  stop_execution_thread();
+}
+
 rclcpp_action::GoalResponse GentlerActionServer::handle_goal(
     const rclcpp_action::GoalUUID &uuid,
     std::shared_ptr<const BaseAction::Goal> goal) {
   (void)uuid;
+
+  if (stop_requested_.load()) {
+    return rclcpp_action::GoalResponse::REJECT;
+  }
 
   // Preemtive check.
   if (!config_.preempt_active_goal) {
@@ -108,6 +136,10 @@ rclcpp_action::CancelResponse GentlerActionServer::handle_cancel(
     const std::shared_ptr<GoalHandle> goal_handle) {
   (void)goal_handle;
 
+  if (stop_requested_.load()) {
+    return rclcpp_action::CancelResponse::REJECT;
+  }
+
   try {
     // Using user-provided OnCancelReceived function.
     return on_cancel_received_() ? rclcpp_action::CancelResponse::ACCEPT
@@ -127,20 +159,24 @@ rclcpp_action::CancelResponse GentlerActionServer::handle_cancel(
 
 void GentlerActionServer::handle_accepted(
     const std::shared_ptr<GoalHandle> goal_handle) {
+  if (stop_requested_.load()) {
+    return;
+  }
+
   {
     std::lock_guard<std::mutex> lock(goal_mutex_);
     active_goal_handle_ = goal_handle;
   }
 
   // TODO: This might block if a running inner_loop with a prior goal does not
-  // exit preemtively, but still gives us clear lifetime management (in 
+  // exit preemtively, but still gives us clear lifetime management (in
   // comparison with the tutorial's implementation).
   stop_execution_thread();
   execution_thread_ =
       std::thread(&GentlerActionServer::execute, this, goal_handle);
 }
 
-/* This is where the magic happens. We're locking the goal_mutex everytime we 
+/* This is where the magic happens. We're locking the goal_mutex everytime we
  * need to read/compare/reset the active_goal_handle to ensure that no other
  * thread is sweeping the rug underneath us. The logic below follows:
  *  1. Check if the goal was preempted.
@@ -162,9 +198,16 @@ void GentlerActionServer::execute(
     rclcpp::Rate rate(config_.loop_frequency_hz);
 
     while (rclcpp::ok()) {
+      if (stop_requested_.load()) {
+        return;
+      }
+
       {
         std::lock_guard<std::mutex> lock(goal_mutex_);
         if (active_goal_handle_ != goal_handle) {
+          if (stop_requested_.load()) {
+            return;
+          }
           result->success = false;
           if (goal_handle->is_active()) {
             goal_handle->abort(result);
@@ -191,6 +234,10 @@ void GentlerActionServer::execute(
 
       // If no need to tamper with the goal, run the user-specified InnerLoop.
       const auto loop_status = loop_inner_();
+      if (stop_requested_.load()) {
+        return;
+      }
+
       if (loop_status == LoopStatus::RUNNING) {
         auto feedback = std::make_shared<BaseAction::Feedback>();
         feedback->feedback.data = give_feedback_();
@@ -239,6 +286,10 @@ void GentlerActionServer::execute(
 }
 
 void GentlerActionServer::publish_heartbeat() {
+  if (stop_requested_.load()) {
+    return;
+  }
+
   std_msgs::msg::String msg;
   msg.data = parsed_action_name_;
   heartbeat_pub_->publish(msg);

--- a/behaviours/smarc/smarc_action_base_cpp/src/graceful_shutdown.cpp
+++ b/behaviours/smarc/smarc_action_base_cpp/src/graceful_shutdown.cpp
@@ -1,0 +1,66 @@
+#include "smarc_action_base_cpp/graceful_shutdown.hpp"
+
+#include <csignal>
+
+namespace smarc_action_base_cpp {
+namespace {
+
+volatile std::sig_atomic_t g_signal_shutdown_requested = 0;
+
+void signal_handler(int)
+{
+  g_signal_shutdown_requested = 1;
+}
+
+}  // namespace
+
+rclcpp::InitOptions manual_signal_handling_init_options()
+{
+  rclcpp::InitOptions init_options;
+  init_options.shutdown_on_signal = false;
+  return init_options;
+}
+
+void install_signal_handlers()
+{
+  reset_signal_shutdown_request();
+  std::signal(SIGINT, signal_handler);
+  std::signal(SIGTERM, signal_handler);
+}
+
+void reset_signal_shutdown_request()
+{
+  g_signal_shutdown_requested = 0;
+}
+
+bool signal_shutdown_requested()
+{
+  return g_signal_shutdown_requested != 0;
+}
+
+void spin_some_for(
+    rclcpp::Executor &executor,
+    std::chrono::milliseconds duration,
+    std::chrono::milliseconds spin_period)
+{
+  const auto start = std::chrono::steady_clock::now();
+  while (rclcpp::ok() && std::chrono::steady_clock::now() - start < duration) {
+    executor.spin_some(spin_period);
+  }
+}
+
+void spin_with_graceful_shutdown(
+    rclcpp::Executor &executor,
+    const ShutdownCallback &on_shutdown,
+    std::chrono::milliseconds spin_period,
+    std::chrono::milliseconds flush_duration)
+{
+  while (rclcpp::ok() && !signal_shutdown_requested()) {
+    executor.spin_some(spin_period);
+  }
+
+  on_shutdown();
+  spin_some_for(executor, flush_duration, spin_period);
+}
+
+}  // namespace smarc_action_base_cpp

--- a/behaviours/smarc/smarc_action_base_cpp/src/super_simple_action_server.cpp
+++ b/behaviours/smarc/smarc_action_base_cpp/src/super_simple_action_server.cpp
@@ -8,6 +8,8 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "smarc_action_base_cpp/gentler_action_server.hpp"
+// This one is very important for handling server shutdowns gracefully!!
+#include "smarc_action_base_cpp/graceful_shutdown.hpp"
 
 namespace smarc_action_base_cpp {
 
@@ -22,7 +24,10 @@ class SuperSimpleAction {
                        std::bind(&SuperSimpleAction::prepare_loop, this),
                        std::bind(&SuperSimpleAction::loop_inner, this),
                        std::bind(&SuperSimpleAction::give_feedback, this),
-                       GentlerActionServer::Config(/*loop_frequency_hz*/5.0)) {}
+                       GentlerActionServer::Config(/*loop_frequency_hz*/ 5.0)) {
+  }
+
+  void request_shutdown() { action_server_.request_shutdown(); }
 
  private:
   using LoopStatus = GentlerActionServer::LoopStatus;
@@ -68,16 +73,31 @@ class SuperSimpleAction {
 }  // namespace smarc_action_base_cpp
 
 int main(int argc, char** argv) {
-  rclcpp::init(argc, argv);
+  // Option to disable ROS' shutdown.
+  auto init_options =
+      smarc_action_base_cpp::manual_signal_handling_init_options();
 
+  // Init node with disabled shutdown. 
+  rclcpp::init(argc, argv, init_options);
+  // Take control of SIGINT and SIGTERM.
+  smarc_action_base_cpp::install_signal_handlers();
+
+  //--These are probably the only few lines you'll need to change in the main.--
   auto node = rclcpp::Node::make_shared("super_simple_action_server_cpp");
   auto action =
       std::make_shared<smarc_action_base_cpp::SuperSimpleAction>(node);
-  (void)action;
-
+  //----------------------------------------------------------------------------
+  
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(node);
-  executor.spin();
+
+  // Make sure to always use our spin + shutdown routine. 
+  smarc_action_base_cpp::spin_with_graceful_shutdown(
+      executor, [&action]() { action->request_shutdown(); });
+
+  executor.remove_node(node);
+  action.reset();
+  node.reset();
 
   rclcpp::shutdown();
   return 0;

--- a/behaviours/smarc/smarc_action_base_cpp/src/super_simple_action_server.cpp
+++ b/behaviours/smarc/smarc_action_base_cpp/src/super_simple_action_server.cpp
@@ -1,0 +1,84 @@
+/* file: super_simple_action_server.cpp
+ * description: Again, pretty much a copy of the SuperSimpleActionServer.py
+ * that lives under smarc2/examples. Here we showcase how to use the c++
+ * GentlerActionServer the same way it was done in the python example.
+ * */
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "smarc_action_base_cpp/gentler_action_server.hpp"
+
+namespace smarc_action_base_cpp {
+
+class SuperSimpleAction {
+ public:
+  explicit SuperSimpleAction(rclcpp::Node::SharedPtr node)
+      : node_(std::move(node)),
+        action_server_(node_, "super_simple_cpp",
+                       std::bind(&SuperSimpleAction::on_goal_received, this,
+                                 std::placeholders::_1),
+                       std::bind(&SuperSimpleAction::on_cancel_received, this),
+                       std::bind(&SuperSimpleAction::prepare_loop, this),
+                       std::bind(&SuperSimpleAction::loop_inner, this),
+                       std::bind(&SuperSimpleAction::give_feedback, this),
+                       GentlerActionServer::Config(/*loop_frequency_hz*/5.0)) {}
+
+ private:
+  using LoopStatus = GentlerActionServer::LoopStatus;
+  using Json = GentlerActionServer::Json;
+
+  bool on_goal_received(const Json& goal) {
+    RCLCPP_INFO(node_->get_logger(), "Received goal: %s", goal.dump().c_str());
+    loop_max_ = goal.value("loop_max", 25);
+    return loop_max_ > 0;
+  }
+
+  bool on_cancel_received() {
+    RCLCPP_INFO(node_->get_logger(), "Received cancel request.");
+    return true;
+  }
+
+  void prepare_loop() {
+    RCLCPP_INFO(node_->get_logger(), "Preparing loop.");
+    looped_for_ = 0;
+  }
+
+  LoopStatus loop_inner() {
+    ++looped_for_;
+    if (looped_for_ >= loop_max_) {
+      RCLCPP_INFO(node_->get_logger(), "Reached %d/%d iterations.", looped_for_,
+                  loop_max_);
+      return LoopStatus::SUCCESS;
+    }
+    return LoopStatus::RUNNING;
+  }
+
+  std::string give_feedback() {
+    return "Action is in progress: " + std::to_string(looped_for_) + "/" +
+           std::to_string(loop_max_);
+  }
+
+  rclcpp::Node::SharedPtr node_;
+  GentlerActionServer action_server_;
+  int looped_for_ = 0;
+  int loop_max_ = 25;
+};
+
+}  // namespace smarc_action_base_cpp
+
+int main(int argc, char** argv) {
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("super_simple_action_server_cpp");
+  auto action =
+      std::make_shared<smarc_action_base_cpp::SuperSimpleAction>(node);
+  (void)action;
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(node);
+  executor.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/behaviours/smarc/smarc_basic_cpp/CMakeLists.txt
+++ b/behaviours/smarc/smarc_basic_cpp/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.8)
+project(smarc_basic_cpp)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(smarc_action_base_cpp REQUIRED)
+
+add_executable(wait_action_cpp
+  src/wait_action.cpp
+)
+ament_target_dependencies(wait_action_cpp
+  rclcpp
+  smarc_action_base_cpp
+)
+
+install(
+  TARGETS wait_action_cpp
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/behaviours/smarc/smarc_basic_cpp/package.xml
+++ b/behaviours/smarc/smarc_basic_cpp/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>smarc_basic_cpp</name>
+  <version>0.0.0</version>
+  <description>C++ implementations of basic SMARC actions.</description>
+  <maintainer email="aldot@kth.se">aldo</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>smarc_action_base_cpp</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/behaviours/smarc/smarc_basic_cpp/src/wait_action.cpp
+++ b/behaviours/smarc/smarc_basic_cpp/src/wait_action.cpp
@@ -1,0 +1,125 @@
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "smarc_action_base_cpp/gentler_action_server.hpp"
+
+namespace smarc_basic_cpp {
+
+class WaitAction
+{
+public:
+  explicit WaitAction(rclcpp::Node::SharedPtr node)
+  : node_(std::move(node)),
+    action_server_(
+      node_,
+      "smarc_wait",
+      std::bind(&WaitAction::on_goal_received, this, std::placeholders::_1),
+      std::bind(&WaitAction::on_cancel_received, this),
+      std::bind(&WaitAction::prepare_loop, this),
+      std::bind(&WaitAction::loop_inner, this),
+      std::bind(&WaitAction::feedback, this),
+      smarc_action_base_cpp::GentlerActionServer::Config(20.0))
+  {
+    reset();
+  }
+
+private:
+  using GentlerActionServer = smarc_action_base_cpp::GentlerActionServer;
+  using Json = GentlerActionServer::Json;
+  using LoopStatus = GentlerActionServer::LoopStatus;
+
+  void reset()
+  {
+    started_waiting_ = rclcpp::Time(0, 0, node_->get_clock()->get_clock_type());
+    has_started_waiting_ = false;
+    timeout_s_ = 0.0;
+    has_timeout_ = false;
+  }
+
+  bool on_goal_received(const Json & goal)
+  {
+    try {
+      timeout_s_ = goal.at("timeout").get<double>();
+      has_timeout_ = true;
+      return timeout_s_ >= 0.0;
+    } catch (const std::exception & error) {
+      RCLCPP_ERROR(node_->get_logger(), "Error parsing timeout: %s", error.what());
+      return false;
+    }
+  }
+
+  bool on_cancel_received()
+  {
+    reset();
+    return true;
+  }
+
+  void prepare_loop()
+  {
+    started_waiting_ = node_->get_clock()->now();
+    has_started_waiting_ = true;
+    RCLCPP_INFO(node_->get_logger(), "Started waiting for %.2f seconds", timeout_s_);
+  }
+
+  double elapsed_time() const
+  {
+    if (!has_started_waiting_) {
+      return -1.0;
+    }
+
+    return (node_->get_clock()->now() - started_waiting_).seconds();
+  }
+
+  LoopStatus loop_inner()
+  {
+    if (!has_started_waiting_ || !has_timeout_) {
+      return LoopStatus::FAILURE;
+    }
+
+    if (elapsed_time() >= timeout_s_) {
+      RCLCPP_INFO(node_->get_logger(), "Finished waiting.");
+      return LoopStatus::SUCCESS;
+    }
+
+    RCLCPP_DEBUG(
+      node_->get_logger(), "Waiting... Elapsed time: %.2f seconds / %.2f seconds",
+      elapsed_time(), timeout_s_);
+    return LoopStatus::RUNNING;
+  }
+
+  std::string feedback() const
+  {
+    if (!has_started_waiting_ || !has_timeout_) {
+      return "Not started";
+    }
+
+    return "Elapsed time: " + std::to_string(elapsed_time()) + " seconds / " +
+           std::to_string(timeout_s_) + " seconds";
+  }
+
+  rclcpp::Node::SharedPtr node_;
+  GentlerActionServer action_server_;
+  rclcpp::Time started_waiting_;
+  bool has_started_waiting_ = false;
+  double timeout_s_ = 0.0;
+  bool has_timeout_ = false;
+};
+
+}  // namespace smarc_basic_cpp
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("wait_action_node_cpp");
+  auto wait_action = std::make_shared<smarc_basic_cpp::WaitAction>(node);
+  (void)wait_action;
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(node);
+  executor.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/behaviours/smarc/smarc_basic_cpp/src/wait_action.cpp
+++ b/behaviours/smarc/smarc_basic_cpp/src/wait_action.cpp
@@ -3,67 +3,65 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "smarc_action_base_cpp/gentler_action_server.hpp"
+#include "smarc_action_base_cpp/graceful_shutdown.hpp"
 
 namespace smarc_basic_cpp {
 
-class WaitAction
-{
-public:
+class WaitAction {
+ public:
   explicit WaitAction(rclcpp::Node::SharedPtr node)
-  : node_(std::move(node)),
-    action_server_(
-      node_,
-      "smarc_wait",
-      std::bind(&WaitAction::on_goal_received, this, std::placeholders::_1),
-      std::bind(&WaitAction::on_cancel_received, this),
-      std::bind(&WaitAction::prepare_loop, this),
-      std::bind(&WaitAction::loop_inner, this),
-      std::bind(&WaitAction::feedback, this),
-      smarc_action_base_cpp::GentlerActionServer::Config(20.0))
-  {
+      : node_(std::move(node)),
+        action_server_(
+            node_, "smarc_wait",
+            std::bind(&WaitAction::on_goal_received, this,
+                      std::placeholders::_1),
+            std::bind(&WaitAction::on_cancel_received, this),
+            std::bind(&WaitAction::prepare_loop, this),
+            std::bind(&WaitAction::loop_inner, this),
+            std::bind(&WaitAction::feedback, this),
+            smarc_action_base_cpp::GentlerActionServer::Config(20.0)) {
     reset();
   }
 
-private:
+  void request_shutdown() { action_server_.request_shutdown(); }
+
+ private:
   using GentlerActionServer = smarc_action_base_cpp::GentlerActionServer;
   using Json = GentlerActionServer::Json;
   using LoopStatus = GentlerActionServer::LoopStatus;
 
-  void reset()
-  {
+  void reset() {
     started_waiting_ = rclcpp::Time(0, 0, node_->get_clock()->get_clock_type());
     has_started_waiting_ = false;
     timeout_s_ = 0.0;
     has_timeout_ = false;
   }
 
-  bool on_goal_received(const Json & goal)
-  {
+  bool on_goal_received(const Json& goal) {
     try {
       timeout_s_ = goal.at("timeout").get<double>();
       has_timeout_ = true;
       return timeout_s_ >= 0.0;
-    } catch (const std::exception & error) {
-      RCLCPP_ERROR(node_->get_logger(), "Error parsing timeout: %s", error.what());
+    } catch (const std::exception& error) {
+      RCLCPP_ERROR(node_->get_logger(), "Error parsing timeout: %s",
+                   error.what());
       return false;
     }
   }
 
-  bool on_cancel_received()
-  {
+  bool on_cancel_received() {
     reset();
     return true;
   }
 
-  void prepare_loop()
-  {
+  void prepare_loop() {
     started_waiting_ = node_->get_clock()->now();
     has_started_waiting_ = true;
-    RCLCPP_INFO(node_->get_logger(), "Started waiting for %.2f seconds", timeout_s_);
+    RCLCPP_INFO(node_->get_logger(), "Started waiting for %.2f seconds",
+                timeout_s_);
   }
 
-  double elapsed_time() const
-  {
+  double elapsed_time() const {
     if (!has_started_waiting_) {
       return -1.0;
     }
@@ -71,8 +69,7 @@ private:
     return (node_->get_clock()->now() - started_waiting_).seconds();
   }
 
-  LoopStatus loop_inner()
-  {
+  LoopStatus loop_inner() {
     if (!has_started_waiting_ || !has_timeout_) {
       return LoopStatus::FAILURE;
     }
@@ -82,14 +79,13 @@ private:
       return LoopStatus::SUCCESS;
     }
 
-    RCLCPP_DEBUG(
-      node_->get_logger(), "Waiting... Elapsed time: %.2f seconds / %.2f seconds",
-      elapsed_time(), timeout_s_);
+    RCLCPP_DEBUG(node_->get_logger(),
+                 "Waiting... Elapsed time: %.2f seconds / %.2f seconds",
+                 elapsed_time(), timeout_s_);
     return LoopStatus::RUNNING;
   }
 
-  std::string feedback() const
-  {
+  std::string feedback() const {
     if (!has_started_waiting_ || !has_timeout_) {
       return "Not started";
     }
@@ -108,17 +104,24 @@ private:
 
 }  // namespace smarc_basic_cpp
 
-int main(int argc, char ** argv)
-{
-  rclcpp::init(argc, argv);
+int main(int argc, char** argv) {
+  auto init_options =
+      smarc_action_base_cpp::manual_signal_handling_init_options();
+  rclcpp::init(argc, argv, init_options);
+  smarc_action_base_cpp::install_signal_handlers();
 
   auto node = rclcpp::Node::make_shared("wait_action_node_cpp");
   auto wait_action = std::make_shared<smarc_basic_cpp::WaitAction>(node);
-  (void)wait_action;
 
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(node);
-  executor.spin();
+
+  smarc_action_base_cpp::spin_with_graceful_shutdown(
+      executor, [&wait_action]() { wait_action->request_shutdown(); });
+
+  executor.remove_node(node);
+  wait_action.reset();
+  node.reset();
 
   rclcpp::shutdown();
   return 0;


### PR DESCRIPTION
## A c++ version of the `smarc_action_base`
I developed and tested the cpp-based `GentlerActionServer`. `smarc_action_base_cpp` includes almost a 1:1 translation of its python counterpart, so anyone looking at developing or translating an action server from python to cpp should be familiar with the interface. 
The `README.md` under `smarc_action_base_cpp`, together with the translated `super_simple_action_server.cpp` and `smarc_basic_cpp/wait_action.cpp`, should make it easy enough for anyone to venture their own action server in cpp.

The `wait_action_cpp` has been tested with the SMARCSim and the BT. **NOTE:** the `wait_action_cpp` node will spawn a normal `wait_action` action server, which will conflict with its python counterpart if they're launched together; **do not run the python version and the cpp version simulatneously.** Not that anyone would, but just FYI!

And yes: **I can be the maintainer!**