### PR TITLE
Integrate yolo_ros and generalize ALARS object estimation

### DIFF
--- a/perception/alars/auv_state_estimation/auv_state_estimation/ekf_node.py
+++ b/perception/alars/auv_state_estimation/auv_state_estimation/ekf_node.py
@@ -8,7 +8,7 @@ import rclpy
 from rclpy.time import Time
 from rclpy.duration import Duration
 from rclpy.node import Node
-from geometry_msgs.msg import PolygonStamped, TransformStamped, PoseWithCovarianceStamped, Vector3Stamped
+from geometry_msgs.msg import PolygonStamped, TransformStamped, PoseWithCovarianceStamped
 from std_msgs.msg import Float32MultiArray
 from nav_msgs.msg import Odometry
 from scipy.stats import chi2
@@ -32,6 +32,7 @@ class EKFNode(Node):
 
         self.logger_info_enable : bool = self.get_parameter("logger_info.enable").get_parameter_value().bool_value
 
+        self.log_info(f"Object name: {self.object_name}")
         self.log_info(f"Motion model type: {self.motion_model_type}")
 
         self.motion_model = self.get_motion_model(self.motion_model_type)
@@ -41,20 +42,43 @@ class EKFNode(Node):
         self.meas_dim = 3 if self.state_dim == 5 else 5
         self.outlier_threshold = chi2.ppf(self.gating_prob, df=self.meas_dim)
 
-        # tf
+        # TF
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
         self.tf_broadcaster = tf2_ros.TransformBroadcaster(self)
 
-        # publishers and subscribers
+        # Publishers
         self.pub = self.create_publisher(PoseWithCovarianceStamped, self.topic_estimated_pose, 10)
         self.pub_status = self.create_publisher(Float32MultiArray, self.topic_ekf_status, 10) 
 
+        # Subscribers
         self.sub_pose = self.create_subscription(PolygonStamped, self.topic_in_poly, self.poly_cb, 10)
         self.sub_odom = self.create_subscription(Odometry, self.topic_odom, self.odom_cb, 10)
-        self.sub_head = self.create_subscription(PolygonStamped, self.topic_input_auv_head, self.head_cb, 10)
 
-        self.reset_srv = self.create_service(Trigger, "alars_auv_ekf/reset", self.handle_reset_service)
+        # In case of AUV estimation, we can optionally subscribe to a head topic
+
+        # Optional head/yaw disambiguation.
+        # For generic object estimation this is disabled by default.
+        self.sub_head = None
+        if self.enable_head_disambiguation and self.topic_input_head != "":
+            self.sub_head = self.create_subscription(
+                PolygonStamped,
+                self.topic_input_head,
+                self.head_cb,
+                10,
+            )
+            self.get_logger().info(
+                f"Head disambiguation enabled. Subscribing to {self.topic_input_head}"
+            )
+        else:
+            self.get_logger().info("Head disambiguation disabled.")
+
+        # Generic object-specific reset service.
+        self.reset_srv = self.create_service(
+            Trigger,
+            self.reset_service,
+            self.handle_reset_service,
+        )
 
         self.current_transform = None
         self.current_cam_pos_map = None
@@ -68,9 +92,19 @@ class EKFNode(Node):
 
         self.initialize_components()
 
-        self.get_logger().info(f"EKF node started. map_frame={self.map_frame}, cam_frame={self.cam_frame}, estimated_auv_frame={self.output_frame}")
+        self.get_logger().info(
+            "EKF node started. "
+            f"object_name={self.object_name}, "
+            f"map_frame={self.map_frame}, "
+            f"cam_frame={self.cam_frame}, "
+            f"output_frame={self.output_frame}, "
+            f"input_polygon={self.topic_in_poly}, "
+            f"output_topic={self.topic_estimated_pose}, "
+            f"reset_service={self.reset_service}"
+        )
 
-        self.q : deque[tuple[PolygonStamped | None, Time | None]] = deque()
+        self.q: deque[tuple[PolygonStamped | None, Time | None]] = deque()
+
         self.timer = self.create_timer(0.01, self.process_q)
         self.status_timer = self.create_timer(0.5, self.publish_status)
         self.check_time_since_last_meas_timer = self.create_timer(0.01, self.check_time_since_last_measurement)
@@ -79,15 +113,15 @@ class EKFNode(Node):
         if self.logger_info_enable:
             self.get_logger().info(msg)
 
-    def poly_cb(self, msg : PolygonStamped):
+    def poly_cb(self, msg: PolygonStamped):
         arrival = self.get_clock().now()
         self.q.append((msg, arrival))
 
     def process_q(self):
         while self.q:
             msg, arrival = self.q[0]
-            
-            if msg is None or arrival is None: 
+
+            if msg is None or arrival is None:
                 self.log_info("Received None message or timestamp in queue, skipping.")
                 self.q.popleft()
                 continue
@@ -109,14 +143,17 @@ class EKFNode(Node):
             else:
                 self.log_info("First measurement received.")
 
-            stamp : Time = Time.from_msg(msg.header.stamp)
+            stamp: Time = Time.from_msg(msg.header.stamp)
             if stamp.seconds_nanoseconds() == (0, 0):
                 self.log_info("Received message with zero timestamp, skipping.")
                 self.q.popleft()
                 continue
 
+            # Use latest available TF instead of exact measurement time.
+            # This avoids lookup-in-the-future problems when images arrive faster than TF.
             check_time = Time(seconds=0)
             check_duration = Duration(seconds=1)
+
             try:
                 transform = self.tf_buffer.lookup_transform(self.map_frame, self.cam_frame, check_time, check_duration)
                 # if self.tf_buffer.can_transform(self.map_frame, self.cam_frame, t, d):
@@ -130,22 +167,28 @@ class EKFNode(Node):
                 self.z(msg, transform)
                 self.last_processed_measurement_time = arrival
                 continue
+
             except Exception as e:
                 self.log_info(f"Cant transform from {self.cam_frame} to {self.map_frame} at msg time, dropping msg.")
                 self.log_info(f"Transform error: {e}")
                 self.q.popleft()
+
                 continue
             break
 
     def pol_to_array(self, msg: PolygonStamped):
-        # polygon -> array of normalized image coordinates
+        # Polygon -> array of normalized image coordinates.
         return np.array([(p.x, p.y) for p in msg.polygon.points])
 
     def head_cb(self, msg: PolygonStamped):
-        # simple voting-based logic to determine the direction of the auv's head.
+        # Optional voting-based logic to determine the direction/front of the object.
+        # Disabled by default for generic object estimation.
+        if not self.enable_head_disambiguation:
+            return
+
         if (not self.ekf.initialized) or (self.current_cam_pos_map is None):
             return
-        pts = self.pol_to_array(msg)
+
         uv_img = self.measurement_model.norm_to_pixels(self.pol_to_array(msg))
         ray = self.measurement_model.back_projection(uv_img[0], self.current_R_map_cam)
         if ray is None:
@@ -171,18 +214,19 @@ class EKFNode(Node):
         self.ang_vel_map = self.current_R_map_cam @ np.array([-msg.twist.twist.angular.x, msg.twist.twist.angular.y, msg.twist.twist.angular.z])
 
     def predict_to_measurement_time(self, dt_total):
-        # perfoems multiple prediction steps between measurements.
-        # this should imporve predictions duering longer time gaps.
+        # Performs multiple prediction steps between measurements.
+        # This improves predictions during longer time gaps.
 
         dt_max = 0.01
         n_steps = max(1, int(np.ceil(dt_total / dt_max)))
         dt_step = dt_total / n_steps
+
         for _ in range(n_steps):
             X, F = self.motion_model.predict(self.ekf.X, dt_step)
             Q = self.motion_model.build_Q(dt_step)
             self.ekf.predict(X, F, Q, self.ekf.last_t + dt_step)
-        return X # type: ignore
-    
+
+        return X
 
     def z(self, msg: PolygonStamped, transform: TransformStamped):
             
@@ -240,12 +284,18 @@ class EKFNode(Node):
             self.nr_of_consecutive_invalid_measurements = 0
         self.log_info(f"Update successful. Post-update state: {X.flatten()[:3]}")
         self.publish_estimate(stamp)
-    
+
     def publish_estimate(self, stamp):
         # publishes the current state estimate as a PoseWithCovarianceStamped message and also broadcasts a TF.
-        flip_decision = np.sum(self.flip_buffer)
         yaw_idx = 2 if self.state_dim == 5 else 3
-        yaw_out = self.ekf.X[yaw_idx, 0] + (np.pi if (flip_decision > 0) else 0.0)
+        yaw_out = self.ekf.X[yaw_idx, 0]
+
+        if self.enable_head_disambiguation:
+            flip_decision = np.sum(self.flip_buffer)
+
+            if flip_decision > 0:
+                yaw_out += np.pi
+
         yaw_out = wrap(yaw_out)
         if self.state_dim == 5:
             q = R.from_euler("z", yaw_out).as_quat()
@@ -263,7 +313,7 @@ class EKFNode(Node):
         self.tf_broadcaster.sendTransform(create_transform_msg(stamp, self.motion_model_type, q, self.map_frame, self.output_frame, self.ekf.X, self.water_surface_height))
 
     def check_time_since_last_measurement(self, max_time_without_meas=0.5):
-        # checks the time since the last measurement and resets the filter if it exceeds a threshold.
+        # Predicts forward if measurements temporarily stop.
         if self.ekf.last_t is None and not self.ekf.initialized:
             return
         now = self.get_clock().now().nanoseconds * 1e-9
@@ -303,22 +353,22 @@ class EKFNode(Node):
             float(self.nr_of_consecutive_invalid_measurements),
             cov_trace,
             innovation_norm,
-            ]
+        ]
 
         self.pub_status.publish(msg)
 
     def handle_reset_service(self, request, response):
         self.reset_filter()
         response.success = True
-        response.message = "EKF reset successfully."
+        response.message = f"{self.object_name} EKF reset successfully."
         return response
-    
+
     def reset_filter(self):
         self.ekf = EKFCore(
             self.water_surface_height,
             state_dim=self.state_dim,
-            outlier_threshold=self.outlier_threshold, # type: ignore
-            #logger=self.get_logger(),
+            outlier_threshold=self.outlier_threshold,
+            logger=self.get_logger(),
         )
 
         self.flip_buffer = [-1]
@@ -329,7 +379,10 @@ class EKFNode(Node):
         self.ang_vel_map = np.zeros(3)
         self.q.clear()
         self.last_processed_measurement_time = None
-        self.get_logger().info("EKF internal state reset.")
+        self.nr_of_consecutive_invalid_measurements = 0
+        self.last_innovation_norm = -1.0
+
+        self.get_logger().info(f"{self.object_name} EKF internal state reset.")
 
     def get_motion_model(self, model_type):
         if model_type == "surface":
@@ -337,20 +390,23 @@ class EKFNode(Node):
                 sigma_a=self.sigma_a_xy,
                 sigma_yaw=self.sigma_yaw,
             )
-        elif model_type == "depth":
+
+        if model_type == "depth":
             return DepthModel(
                 sigma_a=self.sigma_a_xy,
                 sigma_z=self.depth_sigma_z_process,
                 sigma_yaw=self.sigma_yaw,
             )
-        elif model_type == "pitch":
+
+        if model_type == "pitch":
             return PitchModel(
                 sigma_a=self.sigma_a_xy,
                 sigma_z=self.depth_sigma_z_process,
                 sigma_yaw=self.sigma_yaw,
                 sigma_pitch=self.sigma_pitch_process,
             )
-        elif model_type == "oscillator":
+
+        if model_type == "oscillator":
             return OscillatorModel(
                 sigma_a=self.sigma_a_xy,
                 sigma_z=self.oscillator_sigma_z_process,
@@ -358,7 +414,8 @@ class EKFNode(Node):
                 omega=self.oscillator_omega,
                 zeta=self.oscillator_zeta,
             )
-        elif model_type == "double_oscillator":
+
+        if model_type == "double_oscillator":
             return DoubleOscillatorModel(
                 sigma_a=self.sigma_a_xy,
                 sigma_z_slow=self.double_oscillator_sigma_z_slow,
@@ -369,9 +426,9 @@ class EKFNode(Node):
                 omega_fast=self.double_oscillator_omega_fast,
                 zeta_fast=self.double_oscillator_zeta_fast,
             )
-        else:
-            raise ValueError(f"Unknown motion model type: {model_type}")
-        
+
+        raise ValueError(f"Unknown motion model type: {model_type}")
+
     def initialize_components(self):
         self.initializer = Initializer(
             z_water=self.water_surface_height,
@@ -386,6 +443,7 @@ class EKFNode(Node):
             motion_model_type=self.motion_model_type,
             logger=self.get_logger(),
         )
+
         self.measurement_model = MeasurementModel(
             meas_dim=self.meas_dim,
             state_dim=self.state_dim,
@@ -408,7 +466,7 @@ class EKFNode(Node):
             height=self.height,
             R_u=self.R_u,
             R_v=self.R_v,
-            R_alpha=self.R_alpha,   
+            R_alpha=self.R_alpha,
             R_len=self.R_len,
             R_wid=self.R_wid,
             R_pose_x=self.R_pose_x,
@@ -430,45 +488,60 @@ class EKFNode(Node):
             R_dyn_dt=self.R_dyn_dt,
             meas_dim=self.meas_dim,
         )
+
         self.ekf = EKFCore(
             self.water_surface_height,
             state_dim=self.state_dim,
-            outlier_threshold=self.outlier_threshold, # type: ignore
-            logger=self.get_logger(),   
+            outlier_threshold=self.outlier_threshold,
+            logger=self.get_logger(),
         )
 
     def get_params(self):
         PARAMS = [
-            ("topics.input_polygon", Topics.ESTIMATED_AUV_OBB_TOPIC),
-            ("topics.input_auv_head", Topics.ESTIMATED_AUV_HEAD_TOPIC),
-            ("topics.output_topic", "rviz/estimated_pose"),
+            ("object_name", "object"),
+
+            # Generic object input. Must be provided by object_estimation.yaml / launch.
+            ("topics.input_polygon", ""),
+
+            # Optional head topic. Disabled by default.
+            ("topics.input_head", ""),
+
+            # Generic output topic. If empty, it becomes
+            # "<object_name>_projection/pose_with_cov".
+            ("topics.output_topic", ""),
+
             ("topics.odom", SmarcTopics.ODOM_TOPIC),
-            ("topics.ekf_status", "alars_auv_ekf/status"),
+
+            # If empty, it becomes "<object_name>_ekf/status".
+            ("topics.ekf_status", ""),
 
             ("robot_name", "M350"),
             ("frames.map", Links.MAP),
-            ("frames.output_link", Links.ESTIMATED_AUV),
+
+            # Generic output TF frame. If empty, it becomes "estimated_<object_name>".
+            ("frames.output_link", ""),
+
             ("frames.camera", Links.GIMBAL_OPTICAL_FRAME),
 
             ("camera_info", ""),
 
             ("environment.water_surface_height", 0.0),
 
-            # note that these are dimensions of the AUV in the measurement model (OBB), not necessarily the true dimensions of the AUV.
-            ("obb.length_m", 1.3), # auv length in meters, may need to be adjusted
-            ("obb.width_m", 0.16), # auv width in meters, may need to be adjusted
+            # Dimensions of the object model used by the measurement model.
+            ("obb.length_m", 1.3),
+            ("obb.width_m", 0.16),
 
-            ("alpha_line_pixels", 40), # pixels along the alpha direction to compute the front and back rays for yaw estimation in initialization
+            ("alpha_line_pixels", 40), # pixels along the alpha direction to compute the front and back rays for yaw estimation in initialization.
 
-            ("motion.sigma_a_xy", 0.01), # m/s^2, could split up into x, y
-            ("motion.sigma_yaw", 3.0), # deg/s
+            ("motion.sigma_a_xy", 0.01),# m/s^2, could split up into x, y
+            ("motion.sigma_yaw", 3.0), #deg/s
             ("motion.model_type", "double_oscillator"),
 
-            ("depth.sigma_z_process", 1.0), 
+            ("depth.sigma_z_process", 1.0),
             ("depth.k_z", 0.4),
             ("depth.d_z", 0.1),
 
-            ("pitch.sigma_pitch_process", 15.0), 
+            ("pitch.sigma_pitch_process", 15.0),
 
             ("oscillator.sigma_z_process", 5.0),
             ("oscillator.omega", 2.0),
@@ -481,22 +554,21 @@ class EKFNode(Node):
             ("double_oscillator.omega_fast", 2.0),
             ("double_oscillator.zeta_fast", 0.01),
 
-            # measurement noise stddev (pixels)
-            ("measurement_noise.R_u", 10.0), 
+            # Measurement noise stddev (pixels)
+            ("measurement_noise.R_u", 10.0),
             ("measurement_noise.R_v", 10.0),
             ("measurement_noise.R_alpha_deg", 5.0),
             ("measurement_noise.R_len", 200.0),
             ("measurement_noise.R_wid", 40.0),
 
-            # dynamic measurement noise stddev (pixels)
-            # increases with distance from image center
-            ("measurement_noise.center_gain_u", 50.0), 
+            # Dynamic measurement noise stddev (pixels).
+            ("measurement_noise.center_gain_u", 50.0),
             ("measurement_noise.center_gain_v", 50.0),
             ("measurement_noise.center_gain_alpha_deg", 10.0),
             ("measurement_noise.center_gain_len", 10.0),
             ("measurement_noise.center_gain_wid", 10.0),
 
-            # increases with drone speed
+            # Increases with drone speed
             ("measurement_noise.speed_gain_u", 50.0),
             ("measurement_noise.speed_gain_v", 50.0),
             ("measurement_noise.speed_gain_alpha_deg", 10.0),
@@ -505,23 +577,21 @@ class EKFNode(Node):
 
             ("measurement_noise.R_dyn_dt", 0.5),
 
-            # drone pose noise
+            # Drone pose noise.
             ("camera_pose_noise.R_pose_x", 0.03),
             ("camera_pose_noise.R_pose_y", 0.03),
             ("camera_pose_noise.R_pose_z", 0.03),
             ("camera_pose_noise.R_pose_r", 1.0),
             ("camera_pose_noise.R_pose_p", 1.0),
             ("camera_pose_noise.R_pose_yaw", 3.0),
-
-            # dynamic measurement noise update rate (s)
-
+            # Dynamic measurement noise update rate (s)
             ("initialization.min_valid_meas_needed", 5),
             ("initialization.max_pos_spread", 2.0),
             ("initialization.max_yaw_spread", 0.7),
 
             ("gating.prob", 0.99),
 
-            # jacobian epsilons for numerical differentiation
+            # Jacobian epsilon values for numerical differentiation
             ("jacobian.eps_state_pos", 1e-3),
             ("jacobian.eps_state_yaw", 1e-3),
             ("jacobian.eps_state_vel", 1e-3),
@@ -530,11 +600,26 @@ class EKFNode(Node):
 
             ("logger_info.enable", True),
 
-            # if the state is older than this many seconds when a new measurement arrives, reset the filter.
-            ("stale_state_age", 3.0)
-            ]
-        
+            # If true, uses the optional head topic to resolve the 180-degree yaw ambiguity.
+            ("enable_head_disambiguation", False),
+
+            # If empty, it becomes "<object_name>_ekf/reset".
+            ("reset_service", ""),
+
+            # If the state is older than this many seconds, reset the filter.
+            ("stale_state_age", 3.0),
+        ]
+
         self.declare_parameters(namespace="", parameters=PARAMS)
+
+        self.object_name: str = (
+            self.get_parameter("object_name")
+            .get_parameter_value()
+            .string_value
+        )
+
+        if self.object_name == "":
+            self.object_name = "object"
 
         self.water_surface_height :float = self.get_parameter("environment.water_surface_height").get_parameter_value().double_value
 
@@ -603,25 +688,100 @@ class EKFNode(Node):
         self.eps_pose_pos :float = self.get_parameter("jacobian.eps_pose_pos").get_parameter_value().double_value
         self.eps_pose_ang :float = self.get_parameter("jacobian.eps_pose_ang").get_parameter_value().double_value
 
-        self.topic_in_poly : str = self.get_parameter("topics.input_polygon").get_parameter_value().string_value
-        self.topic_input_auv_head : str = self.get_parameter("topics.input_auv_head").get_parameter_value().string_value
-        self.topic_estimated_pose : str = self.get_parameter("topics.output_topic").get_parameter_value().string_value
-        self.topic_odom : str = self.get_parameter("topics.odom").get_parameter_value().string_value
-        self.topic_ekf_status : str = self.get_parameter("topics.ekf_status").get_parameter_value().string_value
+        self.topic_in_poly: str = (
+            self.get_parameter("topics.input_polygon")
+            .get_parameter_value()
+            .string_value
+        )
+
+        if self.topic_in_poly == "":
+            raise RuntimeError(
+                "topics.input_polygon must be set. "
+                "This should come from object_estimation.yaml, e.g. "
+                "alars_detection/auv_obb or alars_detection/buoy_obb."
+            )
+
+        self.topic_input_head: str = (
+            self.get_parameter("topics.input_head")
+            .get_parameter_value()
+            .string_value
+        )
+
+        self.topic_estimated_pose: str = (
+            self.get_parameter("topics.output_topic")
+            .get_parameter_value()
+            .string_value
+        )
+
+        if self.topic_estimated_pose == "":
+            self.topic_estimated_pose = f"{self.object_name}_projection/pose_with_cov"
+
+        self.topic_odom: str = (
+            self.get_parameter("topics.odom")
+            .get_parameter_value()
+            .string_value
+        )
+
+        self.topic_ekf_status: str = (
+            self.get_parameter("topics.ekf_status")
+            .get_parameter_value()
+            .string_value
+        )
+
+        if self.topic_ekf_status == "":
+            self.topic_ekf_status = f"{self.object_name}_ekf/status"
+
+        self.enable_head_disambiguation: bool = (
+            self.get_parameter("enable_head_disambiguation")
+            .get_parameter_value()
+            .bool_value
+        )
+
+        self.reset_service: str = (
+            self.get_parameter("reset_service")
+            .get_parameter_value()
+            .string_value
+        )
+
+        if self.reset_service == "":
+            self.reset_service = f"{self.object_name}_ekf/reset"
 
         # how long do we hold on to the state after last measurement before considering it stale and reinitializing?
         self.stale_state_age : float = self.get_parameter("stale_state_age").get_parameter_value().double_value
-        self.last_processed_measurement_time : Time | None = None
 
+        self.last_processed_measurement_time: Time | None = None
 
-        robot_name : str = self.get_parameter("robot_name").get_parameter_value().string_value
-        map_frame : str = self.get_parameter("frames.map").get_parameter_value().string_value
-        output_frame : str = self.get_parameter("frames.output_link").get_parameter_value().string_value
-        camera_frame : str = self.get_parameter("frames.camera").get_parameter_value().string_value
+        robot_name: str = (
+            self.get_parameter("robot_name")
+            .get_parameter_value()
+            .string_value
+            .strip("/")
+        )
 
-        self.map_frame = f"{robot_name}/{map_frame}"
-        self.output_frame = f"{robot_name}/{output_frame}"
-        self.cam_frame = f"{robot_name}/{camera_frame}"
+        map_frame: str = (
+            self.get_parameter("frames.map")
+            .get_parameter_value()
+            .string_value
+        )
+
+        output_frame: str = (
+            self.get_parameter("frames.output_link")
+            .get_parameter_value()
+            .string_value
+        )
+
+        camera_frame: str = (
+            self.get_parameter("frames.camera")
+            .get_parameter_value()
+            .string_value
+        )
+
+        if output_frame == "":
+            output_frame = f"estimated_{self.object_name}"
+
+        self.map_frame = self.resolve_frame(robot_name, map_frame)
+        self.output_frame = self.resolve_frame(robot_name, output_frame)
+        self.cam_frame = self.resolve_frame(robot_name, camera_frame)
 
         self.width = None
         self.height = None
@@ -639,7 +799,18 @@ class EKFNode(Node):
             self.get_logger().info(f"Loaded CameraInfo from yaml: {self.width}x{self.height}")
         else:
             raise RuntimeError("camera_info parameter must be set")
-        
+
+    @staticmethod
+    def resolve_frame(robot_name: str, frame: str) -> str:
+        frame = str(frame).strip("/")
+
+        if robot_name == "":
+            return frame
+
+        if frame.startswith(f"{robot_name}/"):
+            return frame
+
+        return f"{robot_name}/{frame}"
 
 def main():
     rclpy.init()

--- a/perception/alars/auv_state_estimation/auv_state_estimation/yolo_estimator_adapter.py
+++ b/perception/alars/auv_state_estimation/auv_state_estimation/yolo_estimator_adapter.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+
+import math
+import os
+import yaml
+
+import rclpy
+from rclpy.node import Node
+
+from geometry_msgs.msg import PolygonStamped, Point32
+from std_msgs.msg import Bool
+from std_srvs.srv import Trigger
+
+from yolo_msgs.msg import DetectionArray
+from dji_msgs.msg import Links, Topics
+
+
+class YoloEstimatorAdapter(Node):
+    """
+    Single multi-object adapter from yolo_ros DetectionArray to EKF PolygonStamped inputs.
+
+    It subscribes only to yolo_ros detections.
+
+    It reads object_estimation.yaml and creates one PolygonStamped publisher per object.
+
+    Example:
+      YOLO class "sam"  -> /M350/alars_detection/auv_obb
+      YOLO class "buoy" -> /M350/alars_detection/buoy_obb
+    """
+
+    def __init__(self):
+        super().__init__("yolo_estimator_adapter")
+
+        self.declare_parameter("robot_name", "M350")
+        self.declare_parameter("object_config_file", "")
+        self.declare_parameter("camera_calibration_file", "")
+        self.declare_parameter("topics.yolo_detections", "yolo/detections")
+        self.declare_parameter("frames.camera", Links.GIMBAL_OPTICAL_FRAME)
+        self.declare_parameter("yolo_msg_timeout", 5.0)
+        self.declare_parameter("default_confidence_threshold", 0.5)
+
+        self.robot_name = self.get_str("robot_name").strip("/")
+        self.object_config_file = self.get_str("object_config_file")
+        self.camera_calibration_file = self.get_str("camera_calibration_file")
+        self.yolo_msg_timeout = self.get_float("yolo_msg_timeout")
+        self.default_confidence_threshold = self.get_float(
+            "default_confidence_threshold"
+        )
+
+        if self.robot_name == "":
+            self.robot_name = self.get_namespace().strip("/")
+
+        if self.robot_name == "":
+            self.robot_name = "M350"
+
+        if self.object_config_file == "":
+            raise RuntimeError("object_config_file must be set")
+
+        if self.camera_calibration_file == "":
+            raise RuntimeError("camera_calibration_file must be set")
+
+        self.image_width, self.image_height = self.load_image_size(
+            self.camera_calibration_file
+        )
+
+        camera_frame = self.get_str("frames.camera")
+        self.camera_frame = self.resolve_frame(camera_frame)
+
+        yolo_detections_topic = self.resolve_topic(
+            self.get_str("topics.yolo_detections")
+        )
+
+        self.detector_enabled = True
+        self.last_yolo_msg_time = None
+
+        self.objects = self.load_objects(self.object_config_file)
+        self.object_publishers = {}
+
+        for object_name, cfg in self.objects.items():
+            self.object_publishers[object_name] = self.create_publisher(
+                PolygonStamped,
+                cfg["input_polygon"],
+                10,
+            )
+
+        self.cam_processor_happy_pub = self.create_publisher(
+            Bool,
+            self.resolve_topic(Topics.CAM_PROCESSOR_HAPPY_TOPIC),
+            10,
+        )
+
+        self.create_subscription(
+            DetectionArray,
+            yolo_detections_topic,
+            self.detections_cb,
+            10,
+        )
+
+        self.create_timer(
+            1.0,
+            self.publish_cam_processor_happy,
+        )
+
+        self.create_service(
+            Trigger,
+            self.resolve_topic(Topics.ENABLE_ALARS_DETECTOR_SERVICE_TOPIC),
+            self.handle_enable_detector,
+        )
+
+        self.create_service(
+            Trigger,
+            self.resolve_topic(Topics.DISABLE_ALARS_DETECTOR_SERVICE_TOPIC),
+            self.handle_disable_detector,
+        )
+
+        self.get_logger().info("Multi-object YOLO estimator adapter started")
+        self.get_logger().info(f"Subscribing detections: {yolo_detections_topic}")
+        self.get_logger().info(
+            f"Using image size: {self.image_width}x{self.image_height}"
+        )
+        self.get_logger().info(f"Camera frame: {self.camera_frame}")
+        self.get_logger().info("Configured object outputs:")
+
+        for object_name, cfg in self.objects.items():
+            self.get_logger().info(
+                f"  {object_name}: class_name={cfg['class_name']}, "
+                f"class_id={cfg['class_id']}, "
+                f"threshold={cfg['confidence_threshold']}, "
+                f"topic={cfg['input_polygon']}"
+            )
+
+    def get_str(self, name):
+        return self.get_parameter(name).get_parameter_value().string_value
+
+    def get_float(self, name):
+        return self.get_parameter(name).get_parameter_value().double_value
+
+    def resolve_topic(self, topic):
+        topic = str(topic).strip()
+
+        if topic.startswith("/"):
+            return topic
+
+        return f"/{self.robot_name}/{topic}"
+
+    def resolve_frame(self, frame):
+        frame = str(frame).strip("/")
+
+        if frame.startswith(f"{self.robot_name}/"):
+            return frame
+
+        return f"{self.robot_name}/{frame}"
+
+    def default_input_polygon_for_object(self, object_name):
+        if object_name == "sam":
+            return Topics.ESTIMATED_AUV_OBB_TOPIC
+
+        if object_name == "buoy":
+            return Topics.ESTIMATED_BUOY_OBB_TOPIC
+
+        return f"alars_detection/{object_name}_obb"
+
+    @staticmethod
+    def load_image_size(camera_calibration_file):
+        if not os.path.exists(camera_calibration_file):
+            raise RuntimeError(
+                f"camera_calibration_file does not exist: {camera_calibration_file}"
+            )
+
+        with open(camera_calibration_file, "r") as f:
+            camera_config = yaml.safe_load(f) or {}
+
+        image_width = int(
+            camera_config.get("image_width", camera_config.get("width", 0))
+        )
+        image_height = int(
+            camera_config.get("image_height", camera_config.get("height", 0))
+        )
+
+        if image_width <= 0 or image_height <= 0:
+            raise RuntimeError(
+                f"Could not read image_width/image_height from {camera_calibration_file}"
+            )
+
+        return image_width, image_height
+
+    def load_objects(self, object_config_file):
+        if not os.path.exists(object_config_file):
+            raise RuntimeError(
+                f"object_config_file does not exist: {object_config_file}"
+            )
+
+        with open(object_config_file, "r") as f:
+            object_config = yaml.safe_load(f) or {}
+
+        objects_yaml = object_config.get("objects", {})
+        objects = {}
+
+        for object_name, cfg in objects_yaml.items():
+            if not cfg.get("enabled", True):
+                continue
+
+            input_polygon = cfg.get(
+                "input_polygon",
+                self.default_input_polygon_for_object(object_name),
+            )
+            if input_polygon == "":
+                self.get_logger().warning(
+                    f"Skipping {object_name}: input_polygon is empty"
+                )
+                continue
+
+            class_name = str(cfg.get("class_name", object_name))
+            class_id = int(cfg.get("class_id", -1))
+
+            objects[object_name] = {
+                "class_name": class_name,
+                "class_id": class_id,
+                "confidence_threshold": float(
+                    cfg.get(
+                        "confidence_threshold",
+                        self.default_confidence_threshold,
+                    )
+                ),
+                "input_polygon": self.resolve_topic(input_polygon),
+            }
+
+        if len(objects) == 0:
+            raise RuntimeError(
+                f"No enabled objects with valid input_polygon found in {object_config_file}"
+            )
+
+        return objects
+
+    @property
+    def yolo_is_fresh(self):
+        if self.last_yolo_msg_time is None:
+            return False
+
+        age = (
+            self.get_clock().now().nanoseconds
+            - self.last_yolo_msg_time.nanoseconds
+        ) * 1e-9
+
+        return age < self.yolo_msg_timeout
+
+    def publish_cam_processor_happy(self):
+        msg = Bool()
+        msg.data = self.detector_enabled and self.yolo_is_fresh
+        self.cam_processor_happy_pub.publish(msg)
+
+    def detections_cb(self, msg: DetectionArray):
+        self.last_yolo_msg_time = self.get_clock().now()
+
+        if not self.detector_enabled:
+            return
+
+        best_by_object = {
+            object_name: {
+                "det": None,
+                "score": -1.0,
+            }
+            for object_name in self.objects.keys()
+        }
+
+        for det in msg.detections:
+            for object_name, cfg in self.objects.items():
+                if not self.matches_detection(det, cfg):
+                    continue
+
+                score = float(det.score)
+
+                if score < cfg["confidence_threshold"]:
+                    continue
+
+                w = float(det.bbox.size.x)
+                h = float(det.bbox.size.y)
+
+                if w <= 0.0 or h <= 0.0:
+                    continue
+
+                if score > best_by_object[object_name]["score"]:
+                    best_by_object[object_name]["score"] = score
+                    best_by_object[object_name]["det"] = det
+
+        stamp = msg.header.stamp
+        if stamp.sec == 0 and stamp.nanosec == 0:
+            stamp = self.get_clock().now().to_msg()
+
+        for object_name, best in best_by_object.items():
+            det = best["det"]
+
+            if det is None:
+                continue
+
+            poly = self.detection_to_polygon(det, stamp)
+            self.object_publishers[object_name].publish(poly)
+
+    @staticmethod
+    def matches_detection(det, cfg):
+        det_class_name = str(det.class_name)
+
+        if cfg["class_name"] != "" and det_class_name == cfg["class_name"]:
+            return True
+
+        if cfg["class_id"] >= 0 and int(det.class_id) == cfg["class_id"]:
+            return True
+
+        return False
+
+    def detection_to_polygon(self, det, stamp):
+        cx = float(det.bbox.center.position.x)
+        cy = float(det.bbox.center.position.y)
+        theta = float(det.bbox.center.theta)
+        w = float(det.bbox.size.x)
+        h = float(det.bbox.size.y)
+
+        corners = self.obb_to_corners(cx, cy, w, h, theta)
+
+        msg = PolygonStamped()
+        msg.header.stamp = stamp
+        msg.header.frame_id = self.camera_frame
+
+        for px, py in corners:
+            x_norm, y_norm = self.pixel_to_normalized(px, py)
+
+            p = Point32()
+            p.x = x_norm
+            p.y = y_norm
+            p.z = 0.0
+            msg.polygon.points.append(p)
+
+        return msg
+
+    def pixel_to_normalized(self, px, py):
+        x_norm = ((px - self.image_width / 2.0) / (self.image_width / 2.0))
+        y_norm = ((py - self.image_height / 2.0) / (self.image_height / 2.0))
+
+        return float(x_norm), float(y_norm)
+
+    @staticmethod
+    def obb_to_corners(cx, cy, w, h, theta):
+        local = [
+            (-w / 2.0, -h / 2.0),
+            (w / 2.0, -h / 2.0),
+            (w / 2.0, h / 2.0),
+            (-w / 2.0, h / 2.0),
+        ]
+
+        c = math.cos(theta)
+        s = math.sin(theta)
+
+        corners = []
+
+        for x, y in local:
+            px = cx + x * c - y * s
+            py = cy + x * s + y * c
+            corners.append((px, py))
+
+        return corners          
+
+    def handle_enable_detector(self, request, response):
+        self.detector_enabled = True
+        response.success = True
+        response.message = "YOLO estimator adapter enabled"
+        self.get_logger().info(response.message)
+        return response
+
+    def handle_disable_detector(self, request, response):
+        self.detector_enabled = False
+        response.success = True
+        response.message = "YOLO estimator adapter disabled"
+        self.get_logger().info(response.message)
+        return response
+
+
+def main():
+    rclpy.init()
+    node = YoloEstimatorAdapter()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/perception/alars/auv_state_estimation/config/ekf_params.yaml
+++ b/perception/alars/auv_state_estimation/config/ekf_params.yaml
@@ -1,34 +1,20 @@
 /**:
   ros__parameters:
-    topics:
-      input_polygon: "estimated_auv_obb"
-      input_auv_head: "estimated_auv_head"
-      output_topic: "rviz/estimated_pose"
-      odom: "smarc/odom"
-      ekf_status: "alars_auv_ekf/status"
-
-    frames:
-      map: "map"
-      output_link: "estimated_auv"
-      camera: "z1_optical_frame"
-
-    camera_info: ""
-
     environment:
-      water_surface_height: 0.0 # height of water surface in map frame.
-    
+      water_surface_height: 0.0
+
     obb:
-      length_m: 1.5 # length of the target obb in meters, may need to be adjusted
-      width_m: 0.2 # width of the target obb in meters, may need to be adjusted
+      length_m: 1.0
+      width_m: 0.2
 
     alpha_line_pixels: 40 # number of pixels along length of obb to use for alpha (yaw) measurement in initialization.
 
     motion:
-      sigma_a_xy: 0.03 # acc in x and y (m/s^2) (for all models)
-      sigma_yaw: 3.0 # random walk in yaw (deg/s) (for all models)
+      sigma_a_xy: 0.03                # acc in x and y (m/s^2) (for all models)
+      sigma_yaw: 3.0                  # random walk in yaw (deg/s) (for all models)
       model_type: "double_oscillator" # options: "surface", "depth", "pitch", "oscillator", "double_oscillator"
 
-    # parameters for different motion models, may need to be adjusted based on the environment and target behavior.
+    # Parameters for different motion models, may need to be adjusted based on the environment and target behavior.
     depth.sigma_z_process: 1.0
     depth.k_z: 0.4 # stiffness for depth model, higher means more resistance to depth changes.
     depth.d_z: 0.1 # damping for depth model, higher means more resistance to depth velocity.
@@ -36,53 +22,53 @@
     pitch.sigma_pitch_process: 5.0 # process noise for pitch (deg/s^2) 
 
     oscillator.sigma_z_process: 5.0 # process noise for oscillator in z direction.
-    oscillator.omega: 2.0 # angular velocity of oscillator (rad/s), may need to be adjusted based on water conditions.
-    oscillator.zeta: 0.01 # dampening of oscillator.
+    oscillator.omega: 2.0           # angular velocity of oscillator (rad/s), may need to be adjusted based on water conditions.
+    oscillator.zeta: 0.01           # dampening of oscillator.
 
     double_oscillator.sigma_z_slow: 1.0 # process noise for slow oscillator in z direction.
     double_oscillator.sigma_z_fast: 3.0 # process noise for fast oscillator in z direction.
-    double_oscillator.omega_slow: 1.0 # angular velocity of slow oscillator (rad/s), may need to be adjusted based on water conditions.
-    double_oscillator.zeta_slow: 0.01 # dampening of slow oscillator.
-    double_oscillator.omega_fast: 2.0 # angular velocity of fast oscillator (rad/s), may need to be adjusted based on water conditions.
-    double_oscillator.zeta_fast: 0.01 # dampening of fast oscillator.
+    double_oscillator.omega_slow: 1.0   # angular velocity of slow oscillator (rad/s), may need to be adjusted based on water conditions.
+    double_oscillator.zeta_slow: 0.01   # dampening of slow oscillator.
+    double_oscillator.omega_fast: 2.0   # angular velocity of fast oscillator (rad/s), may need to be adjusted based on water conditions.
+    double_oscillator.zeta_fast: 0.01   # dampening of fast oscillator.
 
-    # measurement noise parameters, note that u is right in the image (x), v is down in the image (y).
+    # Measurement noise parameters, note that u is right in the image (x), v is down in the image (y).
     measurement_noise:
-      R_u: 10.0 # measurement noise for target center u image coordinate (pixels)
-      R_v: 10.0 # measurement noise for target center v image coordinate (pixels)
-      R_alpha_deg: 5.0 # measurement noise for target center alpha (yaw) coordinate (degrees)
-      R_len: 100.0 # measurement noise for target center length coordinate (pixels). As pitch is not included in the state model (except for pitchmodel), pitch is modeled as noise on the length observation.
-      R_wid: 40.0 # measurement noise for target center width coordinate (pixels)
+      R_u: 10.0         # measurement noise for target center u image coordinate (pixels)
+      R_v: 10.0         # measurement noise for target center v image coordinate (pixels)
+      R_alpha_deg: 5.0  # measurement noise for target center alpha (yaw) coordinate (degrees)
+      R_len: 100.0      # measurement noise for target center length coordinate (pixels). As pitch is not included in the state model (except for pitchmodel), pitch is modeled as noise on the length observation.
+      R_wid: 40.0       # measurement noise for target center width coordinate (pixels)
 
-      # parameters for dynamically adjusting measurement noise based on distance from center, for example if the image has high distortion / bad calibration.
-      center_gain_u: 50.0 # measurement noise gain for distance from center in u direction
-      center_gain_v: 50.0 # measurement noise gain for distance from center in v direction.
+      # Parameters for dynamically adjusting measurement noise based on distance from center, for example if the image has high distortion / bad calibration.
+      center_gain_u: 50.0         # measurement noise gain for distance from center in u direction
+      center_gain_v: 50.0         # measurement noise gain for distance from center in v direction.
       center_gain_alpha_deg: 10.0 # measurement noise gain for distance from center in alpha (yaw) direction (degrees).
-      center_gain_len: 50.0 # measurement noise gain for distance from center in length direction.
-      center_gain_wid: 50.0 # measurement noise gain for distance from center in width direction.
+      center_gain_len: 50.0       # measurement noise gain for distance from center in length direction.
+      center_gain_wid: 50.0       # measurement noise gain for distance from center in width direction.
 
-      # parameters for dynamically adjusting measurement noise based on camera/uav speed.
-      speed_gain_u: 50.0 # measurement noise gain in target center u coordinate.
-      speed_gain_v: 50.0 # measurement noise gain in target center v coordinate.
-      speed_gain_alpha_deg: 10.0 # measurement noise gain in target center alpha (yaw) coordinate  (degrees).
-      speed_gain_len: 60.0 # measurement noise gain in target center length coordinate.
-      speed_gain_wid: 30.0 # measurement noise gain in target center width coordinate.
+      # Parameters for dynamically adjusting measurement noise based on camera/uav speed.
+      speed_gain_u: 50.0          # measurement noise gain in target center u coordinate.
+      speed_gain_v: 50.0          # measurement noise gain in target center v coordinate.
+      speed_gain_alpha_deg: 10.0  # measurement noise gain in target center alpha (yaw) coordinate  (degrees).
+      speed_gain_len: 60.0        # measurement noise gain in target center length coordinate.
+      speed_gain_wid: 30.0        # measurement noise gain in target center width coordinate.
 
-      R_dyn_dt: 0.5 # noise in time of measurement, say if there is a delay / incorrect timestamp, while target or camera is moving.
+      R_dyn_dt: 0.5 # noise in time of measurement, say if there is a delay / incorrect timestamp, while target or camera is moving
 
-    # noise of camera pose. This is used in the measurement model to account for the fact that the measurement is taken in the camera frame, but the camera pose is not perfectly known, may need adjustment.
+    # Noise of camera pose. This is used in the measurement model to account for the fact that the measurement is taken in the camera frame, but the camera pose is not perfectly known, may need adjustment.
     camera_pose_noise:
-      R_pose_x: 0.03 # noise in x position of camera/auv pose (meters)
-      R_pose_y: 0.03 # noise in y position of camera/auv pose (meters)
-      R_pose_z: 0.03 # noise in z position of camera/auv pose (meters)
-      R_pose_r: 1.0 # noise in roll angle of camera/auv pose (degrees)
-      R_pose_p: 1.0 # noise in pitch angle of camera/auv pose (degrees)
+      R_pose_x: 0.03  # noise in x position of camera/auv pose (meters)
+      R_pose_y: 0.03  # noise in y position of camera/auv pose (meters)
+      R_pose_z: 0.03  # noise in z position of camera/auv pose (meters)
+      R_pose_r: 1.0   # noise in roll angle of camera/auv pose (degrees)
+      R_pose_p: 1.0   # noise in pitch angle of camera/auv pose (degrees)
       R_pose_yaw: 3.0 # noise in yaw angle of camera/auv pose (degrees)
 
     initialization:
       min_valid_meas_needed: 5 # minimum number of consequtive measurements with low enough spreald to initialize the filter.
-      max_pos_spread: 2.0 # maximum spread in position measurements for initialization (meters).
-      max_yaw_spread: 30.0 # maximum spread in yaw measurements for initialization (degrees).
+      max_pos_spread: 2.0      # maximum spread in position measurements for initialization (meters).
+      max_yaw_spread: 30.0     # maximum spread in yaw measurements for initialization (degrees).
 
     gating:
       prob: 0.99 # gating probability for Mahalanobis distance gating, may need to be adjusted based on measurement noise and outliers.
@@ -97,4 +83,6 @@
     logger_info:
       enable: true
 
+    enable_head_disambiguation: false
+    reset_service: ""
     stale_state_age: 3.0

--- a/perception/alars/auv_state_estimation/config/object_estimation.yaml
+++ b/perception/alars/auv_state_estimation/config/object_estimation.yaml
@@ -1,0 +1,40 @@
+# This file contains the configuration for the object estimation EKF nodes. 
+# In case to estimate a new object, it should be added here with its parameters.
+objects:
+  sam:
+    enabled: true
+    class_name: "sam"
+    confidence_threshold: 0.5
+
+    length_m: 1.3
+    width_m: 0.16
+    motion_model_type: "double_oscillator"
+    stale_state_age: 3.0
+
+    enable_head_disambiguation: false
+
+    parameters:
+      motion:
+        sigma_a_xy: 0.03
+      measurement_noise:
+        R_len: 100.0
+        R_wid: 40.0
+
+  buoy:
+    enabled: true
+    class_name: "buoy"
+    confidence_threshold: 0.5
+
+    length_m: 0.27
+    width_m: 0.09
+    motion_model_type: "surface"
+    stale_state_age: 10.0
+
+    enable_head_disambiguation: false
+
+    parameters:
+      motion:
+        sigma_a_xy: 0.01
+      measurement_noise:
+        R_len: 80.0
+        R_wid: 40.0

--- a/perception/alars/auv_state_estimation/launch/object_ekf_launch.py
+++ b/perception/alars/auv_state_estimation/launch/object_ekf_launch.py
@@ -1,0 +1,235 @@
+import os
+import yaml
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction, LogInfo
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+from dji_msgs.msg import Links, Topics
+from smarc_msgs.msg import Topics as SmarcTopics
+
+# Default configuration for known objects. If an object is not listed here, the defaults_for_object function will generate default values based on the object name.
+OBJECT_DEFAULTS = {
+    "sam": {
+        "input_polygon": Topics.ESTIMATED_AUV_OBB_TOPIC,
+        "input_head": Topics.ESTIMATED_AUV_HEAD_TOPIC,
+        "output_topic": Topics.PROJECTED_AUV_POSE_WITH_COV_TOPIC,
+        "output_link": Links.ESTIMATED_AUV,
+        "ekf_status": "alars_auv_ekf/status",
+        "reset_service": "alars_auv_ekf/reset",
+    },
+    "buoy": {
+        "input_polygon": Topics.ESTIMATED_BUOY_OBB_TOPIC,
+        "input_head": "",
+        "output_topic": Topics.PROJECTED_BUOY_POSE_WITH_COV_TOPIC,
+        "output_link": Links.ESTIMATED_BUOY,
+        "ekf_status": "buoy_ekf/status",
+        "reset_service": "buoy_ekf/reset",
+    },
+}
+
+def defaults_for_object(object_name):
+    if object_name in OBJECT_DEFAULTS:
+        return OBJECT_DEFAULTS[object_name]
+
+    return {
+        "input_polygon": f"alars_detection/{object_name}_obb",
+        "input_head": "",
+        "output_topic": f"alars_projection/{object_name}_pose_with_cov",
+        "output_link": f"estimated_{object_name}",
+        "ekf_status": f"{object_name}_ekf/status",
+        "reset_service": f"{object_name}_ekf/reset",
+    }
+
+def as_bool(value):
+    return str(value).lower() in ["true", "1", "yes"]
+
+
+def resolve_config_path(pkg_dir, value):
+    if os.path.isabs(value):
+        return value
+
+    return os.path.join(pkg_dir, "config", value)
+
+
+def flatten_params(params, prefix=""):
+    flat = {}
+
+    for key, value in params.items():
+        full_key = f"{prefix}.{key}" if prefix else key
+
+        if isinstance(value, dict):
+            flat.update(flatten_params(value, full_key))
+        else:
+            flat[full_key] = value
+
+    return flat
+
+
+def launch_setup(context, *args, **kwargs):
+    pkg_dir = get_package_share_directory("auv_state_estimation")
+
+    robot_name = LaunchConfiguration("robot_name").perform(context)
+    use_sim_time = as_bool(LaunchConfiguration("use_sim_time").perform(context))
+
+    base_params_file_name = LaunchConfiguration("base_params_file").perform(context)
+    object_config_file_name = LaunchConfiguration("object_config_file").perform(context)
+    camera_calibration_file_name = LaunchConfiguration(
+        "camera_calibration_file"
+    ).perform(context)
+
+    yolo_detections_topic = LaunchConfiguration(
+        "yolo_detections_topic"
+    ).perform(context)
+
+    base_params_file = resolve_config_path(pkg_dir, base_params_file_name)
+    object_config_file = resolve_config_path(pkg_dir, object_config_file_name)
+    camera_calibration_file = resolve_config_path(
+        pkg_dir,
+        camera_calibration_file_name,
+    )
+
+    with open(object_config_file, "r") as f:
+        object_config = yaml.safe_load(f) or {}
+
+    objects = object_config.get("objects", {})
+
+    launch_entities = [
+        LogInfo(msg=["[object_ekf_launch] base params file = ", base_params_file]),
+        LogInfo(msg=["[object_ekf_launch] object config file = ", object_config_file]),
+        LogInfo(msg=["[object_ekf_launch] camera calibration file = ", camera_calibration_file]),
+        LogInfo(msg=["[object_ekf_launch] yolo detections topic = ", yolo_detections_topic]),
+    ]
+
+    # One shared adapter for all enabled objects.
+    launch_entities.append(
+        Node(
+            package="auv_state_estimation",
+            executable="yolo_estimator_adapter",
+            namespace=robot_name,
+            name="yolo_estimator_adapter",
+            output="screen",
+            parameters=[
+                {
+                    "robot_name": robot_name,
+                    "use_sim_time": use_sim_time,
+
+                    "object_config_file": object_config_file,
+                    "camera_calibration_file": camera_calibration_file,
+
+                    "topics.yolo_detections": yolo_detections_topic,
+
+                    "frames.camera": Links.GIMBAL_OPTICAL_FRAME,
+
+                    "yolo_msg_timeout": 5.0,
+                    "default_confidence_threshold": 0.5,
+                }
+            ],
+        )
+    )
+
+    for object_name, cfg in objects.items():
+        if not cfg.get("enabled", True):
+            continue
+
+        defaults = defaults_for_object(object_name)
+
+        object_params = {
+            "object_name": object_name,
+            "robot_name": robot_name,
+            "use_sim_time": use_sim_time,
+
+            "camera_info": camera_calibration_file,
+
+            "topics.input_polygon": cfg.get("input_polygon", defaults["input_polygon"]),
+            "topics.input_head": cfg.get("input_head", defaults["input_head"]),
+            "topics.output_topic": cfg.get("output_topic", defaults["output_topic"]),
+            "topics.ekf_status": cfg.get("ekf_status", defaults["ekf_status"]),
+            
+            "topics.odom": SmarcTopics.ODOM_TOPIC,
+            "frames.map": Links.MAP,
+            "frames.camera": Links.GIMBAL_OPTICAL_FRAME,
+            
+            "frames.output_link": cfg.get("output_link", defaults["output_link"]),
+
+            "obb.length_m": float(cfg["length_m"]),
+            "obb.width_m": float(cfg["width_m"]),
+
+            "motion.model_type": cfg.get("motion_model_type", "surface"),
+            "stale_state_age": float(cfg.get("stale_state_age", 3.0)),
+
+            "enable_head_disambiguation": bool(
+                cfg.get("enable_head_disambiguation", False)
+            ),
+
+            "reset_service": cfg.get("reset_service", defaults["reset_service"]),
+        }   
+
+        extra_params = cfg.get("parameters", {})
+        if extra_params:
+            object_params.update(flatten_params(extra_params))
+
+        launch_entities.append(
+            LogInfo(
+                msg=[
+                    "[object_ekf_launch] launching ",
+                    object_name,
+                    " EKF | input polygon: ",
+                    object_params["topics.input_polygon"],
+                    " | output pose: ",
+                    object_params["topics.output_topic"],
+                    " | frame: ",
+                    object_params["frames.output_link"],
+                ]
+            )
+        )
+
+        launch_entities.append(
+            Node(
+                package="auv_state_estimation",
+                executable="ekf_node",
+                namespace=robot_name,
+                name=f"{object_name}_ekf_node",
+                output="screen",
+                parameters=[
+                    base_params_file,
+                    object_params,
+                ],
+            )
+        )
+
+    return launch_entities
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "robot_name",
+                default_value="M350",
+            ),
+            DeclareLaunchArgument(
+                "use_sim_time",
+                default_value="false",
+            ),
+            DeclareLaunchArgument(
+                "camera_calibration_file",
+                default_value="cam_params.yaml",
+            ),
+            DeclareLaunchArgument(
+                "base_params_file",
+                default_value="ekf_params.yaml",
+            ),
+            DeclareLaunchArgument(
+                "object_config_file",
+                default_value="object_estimation.yaml",
+            ),
+            DeclareLaunchArgument(
+                "yolo_detections_topic",
+                default_value="yolo/detections",
+            ),
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/perception/alars/auv_state_estimation/setup.py
+++ b/perception/alars/auv_state_estimation/setup.py
@@ -20,8 +20,8 @@ setup(
     zip_safe=True,
     maintainer='sebbe',
     maintainer_email='sebbe@todo.todo',
-    description='TODO: Package description',
-    license='TODO: License declaration',
+    description='ROS2 package for ALARS state estimation',
+    license='MIT',
     extras_require={
         'test': [
             'pytest',
@@ -31,6 +31,7 @@ setup(
         'console_scripts': [
             'projection = auv_state_estimation.projection:main',
             'ekf_node = auv_state_estimation.ekf_node:main',
+            'yolo_estimator_adapter = auv_state_estimation.yolo_estimator_adapter:main',
         ],
     },
 )

--- a/scripts/smarc_bringups/scripts/dji_bringup.sh
+++ b/scripts/smarc_bringups/scripts/dji_bringup.sh
@@ -254,30 +254,36 @@ if [[ "$NO_CAM" == "True" ]]; then
     PROJECTION_CMD="echo 'Camera disabled, not launching projection node'"
 else
     YOLO_DEVICE=0
+    YOLO_THRESHOLD=0.5
     CAM_CALIBRATION_FILE="z1_720p_cam_params.yaml"
     YOLO_MODEL="yolo_model_2cls_may.pt" # Options: alars_labeling_training/trained_models
+    OBJECT_CONFIG_FILE="object_estimation.yaml" # Config file to edit each object's parameters for the EKF 
+    
     if [[ $USE_SIM_TIME = "True" ]]; then
         YOLO_DEVICE=cpu
         CAM_CALIBRATION_FILE="sim_1080p_cam_params.yaml"
         # seems to be doing better in sim
         YOLO_MODEL="yolo_model_2cls_mixed.pt"
     fi
-    YOLO_CMD="ros2 launch alars_auv_perception alars_yolo_detector.launch.py \
-    robot_name:=$ROBOT_NAME \
-    device:=$YOLO_DEVICE \
-    use_sim_time:=$USE_SIM_TIME \
-    model_package:=alars_labeling_training \
-    model_file:=$YOLO_MODEL"
 
-    PROJECTION_CMD="ros2 launch auv_state_estimation auv_buoy_ekf_launch.py \
+    YOLO_CMD="ros2 launch yolo_bringup yolocustom.launch.py \
+    robot_name:=$ROBOT_NAME \
+    model_package:=alars_labeling_training \
+    model_subdir:=trained_models \
+    model_file:=$YOLO_MODEL \
+    namespace:=$ROBOT_NAME/yolo \
+    device:=$YOLO_DEVICE \
+    threshold:=$YOLO_THRESHOLD
+    "
+
+    # Creates the projection of every object considered in the object_config_file
+    PROJECTION_CMD="ros2 launch auv_state_estimation object_ekf_launch.py \
     robot_name:=$ROBOT_NAME \
     use_sim_time:=$USE_SIM_TIME \
     camera_calibration_file:=$CAM_CALIBRATION_FILE \
-    auv_ekf_staleness_seconds:=$EKF_STALENESS_SECONDS \
-    buoy_ekf_staleness_seconds:=10.0 \
-    auv_length_m:=$AUV_LENGTH_M \
-    auv_width_m:=$AUV_WIDTH_M
+    object_config_file:=$OBJECT_CONFIG_FILE
     "
+
 fi
 
 tmux_make_layout "$SESSION" CamProc "


### PR DESCRIPTION
Update the ALARS perception and estimation pipeline to make object estimation more flexible. Any detection can now be estimated if it is defined in the configuration file, and the pipeline now uses the updated `yolo_ros` submodule launch setup.

Changes:

- Updated the `yolo_ros` submodule pointer to include a configurable launch file with support for selecting custom yolo models.
- Added a yolo estimator adapter for object estimation:
  - Publishes one `PolygonStamped` topic per configured object, format expected by the estimation pipeline
  - Fixes coordinate and pixel adaptation between detection and estimation.
- Updated `ekf_params.yaml` to remove hardcoded frames/topics and use a cleaner generic parameter structure before launching one node per object.
- Added `object_estimation.yaml` for YAML-based object estimation configuration, where new objects can be added for projection/estimation.
- Updated `ekf_node.py` to include the generic parameter structure.
- Added a dedicated object EKF launch file for the new setup.
- Updated `dji_bringup.sh` to launch the updated `yolo_ros` file and the new estimation setup, using a model path selection similar to the previous perception launch and new variables: YOLO_THRESHOLD and OBJECT_CONFIG_FILE.