### PR TITLE
Add configurable multi-object EKF estimation and yolo_ros integration

### DIFF
--- a/messages/dji_msgs/CMakeLists.txt
+++ b/messages/dji_msgs/CMakeLists.txt
@@ -20,6 +20,14 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Links.msg"          # links for drone
   "msg/PsdkTopics.msg"     # base topics from psdk_wrapper    
   "msg/LabeledOBBs.msg"    # custom message for labeled object detections
+
+  "msg/ObjectPoseWithCovariance.msg"       # estimated object pose with covariance matrix
+  "msg/ObjectPoseWithCovarianceArray.msg"  # array of estimated object poses with covariance
+  "msg/ObjectEkfStatus.msg"                # EKF status information for a single estimated object
+  "msg/ObjectEkfStatusArray.msg"           # array of EKF status for all estimated objects
+  
+  "srv/ResetObjectEkf.srv"                 # service to reset EKF filters
+
   "srv/DronePath.srv"
   "srv/InitAUVSearch.srv"  
   DEPENDENCIES geometry_msgs sensor_msgs std_msgs geographic_msgs

--- a/messages/dji_msgs/msg/ObjectEkfStatus.msg
+++ b/messages/dji_msgs/msg/ObjectEkfStatus.msg
@@ -1,0 +1,14 @@
+# EKF status information for a single estimated object
+std_msgs/Header header
+
+string class_name
+
+bool initialized
+float64 time_since_last_processed_measurement
+float64 time_since_last_update
+
+int32 consecutive_outliers
+int32 consecutive_invalid_measurements
+
+float64 covariance_trace
+float64 innovation_norm

--- a/messages/dji_msgs/msg/ObjectEkfStatusArray.msg
+++ b/messages/dji_msgs/msg/ObjectEkfStatusArray.msg
@@ -1,0 +1,4 @@
+# Array of EKF status for all estimated objects
+std_msgs/Header header
+
+dji_msgs/ObjectEkfStatus[] statuses

--- a/messages/dji_msgs/msg/ObjectPoseWithCovariance.msg
+++ b/messages/dji_msgs/msg/ObjectPoseWithCovariance.msg
@@ -1,0 +1,9 @@
+# Estimated object pose with covariance matrix
+std_msgs/Header header
+
+string class_name
+
+# Can be useful later for debug
+# float64 score
+
+geometry_msgs/PoseWithCovariance pose

--- a/messages/dji_msgs/msg/ObjectPoseWithCovarianceArray.msg
+++ b/messages/dji_msgs/msg/ObjectPoseWithCovarianceArray.msg
@@ -1,0 +1,4 @@
+# Array of estimated object poses with covariance
+std_msgs/Header header
+
+dji_msgs/ObjectPoseWithCovariance[] objects

--- a/messages/dji_msgs/msg/Topics.msg
+++ b/messages/dji_msgs/msg/Topics.msg
@@ -65,4 +65,10 @@ string PROJECTED_BUOY_POSE_WITH_COV_TOPIC = 'alars_projection/buoy_pose_with_cov
 string ENABLE_ALARS_DETECTOR_SERVICE_TOPIC = 'enable_alars_detector' # Trigger
 string DISABLE_ALARS_DETECTOR_SERVICE_TOPIC = 'disable_alars_detector' # Trigger
 
+# Multi-object estimation outputs.
+string PROJECTED_OBJECT_POSES_ARRAY_TOPIC = 'alars_projection/object_poses_array' # dji_msgs/ObjectPoseWithCovarianceArray
+string OBJECT_EKF_STATUS_ARRAY_TOPIC = 'alars_ekf/status_array' # dji_msgs/ObjectEkfStatusArray
+string OBJECT_EKF_RESET_SERVICE = 'alars_ekf/reset' # dji_msgs/ResetObjectEkf
 
+# Only for visualization
+string OBJECT_EKF_MARKERS_TOPIC = 'alars_projection/object_pose_markers' # visualization_msgs/MarkerArray

--- a/messages/dji_msgs/srv/ResetObjectEkf.srv
+++ b/messages/dji_msgs/srv/ResetObjectEkf.srv
@@ -1,0 +1,7 @@
+# Service to reset EKF filters
+# Use object_name: "all" to reset all object EKFs.
+
+string class_name
+---
+bool success
+string message

--- a/perception/alars/auv_state_estimation/auv_state_estimation/multi_object_ekf_node.py
+++ b/perception/alars/auv_state_estimation/auv_state_estimation/multi_object_ekf_node.py
@@ -1,0 +1,490 @@
+import math
+import yaml
+import numpy as np
+
+import rclpy
+from rclpy.node import Node
+from rclpy.time import Time
+from rclpy.duration import Duration
+
+from geometry_msgs.msg import PolygonStamped, Point
+from nav_msgs.msg import Odometry
+from scipy.spatial.transform import Rotation as R
+import tf2_ros
+
+from dji_msgs.msg import Links, Topics, ObjectPoseWithCovarianceArray, ObjectEkfStatusArray
+
+from dji_msgs.srv import ResetObjectEkf
+from smarc_msgs.msg import Topics as SmarcTopics
+from yolo_msgs.msg import DetectionWithCornersArray
+from visualization_msgs.msg import Marker, MarkerArray
+
+from .object_ekf import ObjectEKF
+
+class MultiObjectEKFNode(Node):
+    def __init__(self):
+        super().__init__("multi_object_ekf_node")
+
+        # Input
+        self.declare_parameter("topics.input_detections_corners", "yolo/detections_with_corners")
+
+        # Outputs for all estimated objects.
+        self.declare_parameter("topics.output_poses_array", Topics.PROJECTED_OBJECT_POSES_ARRAY_TOPIC)
+        self.declare_parameter("topics.status_array", Topics.OBJECT_EKF_STATUS_ARRAY_TOPIC)
+
+        # Visualization
+        self.declare_parameter("visualization.enable", True)
+        self.declare_parameter("visualization_enable", True)
+        self.declare_parameter("topics.markers", Topics.OBJECT_EKF_MARKERS_TOPIC)
+
+        # Multi-object reset service.
+        self.declare_parameter("services.reset", Topics.OBJECT_EKF_RESET_SERVICE)
+
+        self.declare_parameter("robot_name", "M350")
+        self.declare_parameter("frames.map", Links.MAP)
+        self.declare_parameter("frames.camera", Links.GIMBAL_OPTICAL_FRAME)
+
+        # Camera and EKF config files
+        self.declare_parameter("base_params_file", "")
+        self.declare_parameter("object_config_file", "")
+        self.declare_parameter("camera_info", "")
+
+        # Odom topic
+        self.declare_parameter("topics.odom", SmarcTopics.ODOM_TOPIC)
+
+        self.robot_name = self.get_parameter("robot_name").get_parameter_value().string_value.strip("/")
+
+        map_frame = self.get_parameter("frames.map").get_parameter_value().string_value
+        camera_frame = self.get_parameter("frames.camera").get_parameter_value().string_value
+
+        self.map_frame = self.resolve_frame(map_frame)
+        self.cam_frame = self.resolve_frame(camera_frame)
+
+        base_params_file = self.get_parameter("base_params_file").get_parameter_value().string_value
+        object_config_file = self.get_parameter("object_config_file").get_parameter_value().string_value
+        camera_info_file = self.get_parameter("camera_info").get_parameter_value().string_value
+
+        if base_params_file == "":
+            raise RuntimeError("base_params_file must be set")
+
+        if object_config_file == "":
+            raise RuntimeError("object_config_file must be set")
+
+        if camera_info_file == "":
+            raise RuntimeError("camera_info parameter must be set")
+
+        base_params = ObjectEKF.flatten_params(self.load_ros_params_yaml(base_params_file))
+        object_config = self.load_ros_params_yaml(object_config_file)
+        camera_info = self.load_camera_info(camera_info_file)
+
+        self.input_detections_corners_topic = self.get_parameter("topics.input_detections_corners").get_parameter_value().string_value
+        self.output_poses_array_topic = self.get_parameter("topics.output_poses_array").get_parameter_value().string_value
+        self.status_array_topic = self.get_parameter("topics.status_array").get_parameter_value().string_value
+        flat_visualization_enabled = self.get_parameter("visualization_enable").get_parameter_value().bool_value
+        nested_visualization_enabled = self.get_parameter("visualization.enable").get_parameter_value().bool_value
+        self.visualization_enable = bool(flat_visualization_enabled and nested_visualization_enabled)
+        self.markers_topic = self.get_parameter("topics.markers").get_parameter_value().string_value
+        self.reset_service_name = self.get_parameter("services.reset").get_parameter_value().string_value
+        self.odom_topic = self.get_parameter("topics.odom").get_parameter_value().string_value
+        
+        self.tracks = {}
+
+        classes = object_config.get("classes", object_config.get("objects", {}))
+
+        # Create one EKF instance per configured class.
+        # The ObjectEKF class contains the original single-object EKF logic.
+        for class_name, cfg in classes.items():
+            if not cfg.get("enabled", True):
+                continue
+
+            self.tracks[class_name] = ObjectEKF(
+                class_name=class_name,
+                cfg=cfg,
+                base_params=base_params,
+                camera_info=camera_info,
+                logger=self.get_logger(),
+            )
+
+        if len(self.tracks) == 0:
+            raise RuntimeError("No enabled objects found in object_config_file")
+
+        # tf
+        self.tf_buffer = tf2_ros.Buffer()
+        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
+
+        self.current_R_map_cam = None
+        self.lin_vel_map = np.zeros(3)
+        self.ang_vel_map = np.zeros(3)
+
+        # Publishers
+        self.pub_poses = self.create_publisher(ObjectPoseWithCovarianceArray, self.output_poses_array_topic, 10)
+        self.pub_status = self.create_publisher(ObjectEkfStatusArray, self.status_array_topic, 10)
+        
+        self.pub_markers = None
+        if self.visualization_enable:
+            self.pub_markers = self.create_publisher(MarkerArray, self.markers_topic, 10)
+
+        # Subscribers
+        self.sub_detections = self.create_subscription(DetectionWithCornersArray, self.input_detections_corners_topic, self.detections_cb, 10)
+        self.sub_odom = self.create_subscription(Odometry, self.odom_topic, self.odom_cb, 10)
+
+        # Reset service
+        self.reset_srv = self.create_service(ResetObjectEkf, self.reset_service_name, self.handle_reset)
+
+        self.status_timer = self.create_timer(0.5, self.publish_status_array)
+
+        self.get_logger().info(
+            "Multi-object EKF node started. "
+            f"classes={list(self.tracks.keys())}, "
+            f"map_frame={self.map_frame}, "
+            f"cam_frame={self.cam_frame}, "
+            f"input_detections_corners={self.input_detections_corners_topic}, "
+            f"output_poses_array={self.output_poses_array_topic}, "
+            f"status_array={self.status_array_topic}, "
+            f"Markers visualization={self.visualization_enable}, "
+            f"reset_service={self.reset_service_name}"
+        )
+
+    @staticmethod
+    def load_ros_params_yaml(path):
+        with open(path, "r") as f:
+            data = yaml.safe_load(f) or {}
+
+        if "/**" in data:
+            return data["/**"].get("ros__parameters", {})
+
+        return data
+
+    @staticmethod
+    def load_camera_info(path):
+        with open(path, "r") as f:
+            calib = yaml.safe_load(f) or {}
+
+        return {
+            "width": int(calib["image_width"]),
+            "height": int(calib["image_height"]),
+            "K": np.array(calib["camera_matrix"]["data"]).reshape(3, 3),
+            "D": np.array(calib["distortion_coefficients"]["data"]),
+        }
+
+    def detections_cb(self, msg: DetectionWithCornersArray):
+        # Shared detection callback.
+        # Each configured ObjectEKF selects the best detection for its class.
+        transform = self.lookup_camera_transform()
+
+        if transform is None:
+            return
+
+        cam_pos_map, R_map_cam = self.transform_to_pose(transform)
+        self.current_R_map_cam = R_map_cam
+
+        now = self.get_clock().now()
+
+        for track in self.tracks.values():
+            best_det = self.find_best_detection(track, msg.detections)
+
+            if best_det is None:
+                continue
+
+            poly_msg = PolygonStamped()
+            poly_msg.header = msg.header
+            poly_msg.header.frame_id = self.cam_frame
+            poly_msg.polygon = best_det.bbox.normalized_corners
+
+            track.last_detection_score = float(best_det.score)
+
+            track.z(
+                msg=poly_msg,
+                cam_pos_map=cam_pos_map,
+                R_map_cam=R_map_cam,
+                lin_vel_map=self.lin_vel_map,
+                ang_vel_map=self.ang_vel_map,
+                now=now,
+            )
+
+        stamp = msg.header.stamp
+
+        if stamp.sec == 0 and stamp.nanosec == 0:
+            stamp = self.get_clock().now().to_msg()
+
+        self.publish_pose_array(stamp)
+
+    def find_best_detection(self, track, detections):
+        best_det = None
+        best_score = -1.0
+
+        for det in detections:
+            if not track.matches_detection(det):
+                continue
+
+            score = float(det.score)
+
+            if score < track.confidence_threshold:
+                continue
+
+            if len(det.bbox.normalized_corners.points) < 4:
+                continue
+
+            if score > best_score:
+                best_score = score
+                best_det = det
+
+        return best_det
+
+    def lookup_camera_transform(self):
+        # Use latest available TF instead of exact measurement time.
+        # This avoids lookup-in-the-future problems when images arrive faster than TF.
+        check_time = Time(seconds=0)
+        check_duration = Duration(seconds=1)
+        try:
+            return self.tf_buffer.lookup_transform(self.map_frame, self.cam_frame, check_time, check_duration)
+        except Exception as e:
+            self.get_logger().warn(
+                f"Cant transform from {self.cam_frame} to {self.map_frame}, dropping msg."
+            )
+            self.get_logger().warn(f"Transform error: {e}")
+            return None
+
+    @staticmethod
+    def transform_to_pose(transform):
+        t = transform.transform.translation
+        q = transform.transform.rotation
+
+        cam_pos_map = np.array([t.x, t.y, t.z])  # Actually the optical frame
+        R_map_cam = R.from_quat([q.x, q.y, q.z, q.w]).as_matrix()
+
+        return cam_pos_map, R_map_cam
+
+    def odom_cb(self, msg: Odometry):
+        if self.current_R_map_cam is None:
+            return
+        self.lin_vel_map = self.current_R_map_cam @ np.array([-msg.twist.twist.linear.x, msg.twist.twist.linear.y, msg.twist.twist.linear.z])
+        self.ang_vel_map = self.current_R_map_cam @ np.array([-msg.twist.twist.angular.x, msg.twist.twist.angular.y, msg.twist.twist.angular.z])
+
+    def publish_pose_array(self, stamp):
+        out = ObjectPoseWithCovarianceArray()
+        out.header.stamp = stamp
+        out.header.frame_id = self.map_frame
+
+        marker_array = MarkerArray()
+
+        if self.visualization_enable:
+            # Clear old markers every update.
+            clear_marker = Marker()
+            clear_marker.action = Marker.DELETEALL
+            marker_array.markers.append(clear_marker)
+
+        marker_id = 0
+
+        for track in self.tracks.values():
+            pose_msg = track.create_estimate_msg(stamp, self.map_frame)
+
+            if pose_msg is None:
+                continue
+
+            out.objects.append(pose_msg)
+
+            if self.visualization_enable:
+                markers = self.make_object_markers(
+                    pose_msg=pose_msg,
+                    marker_id_start=marker_id,
+                )
+
+                marker_array.markers.extend(markers)
+                marker_id += 10
+
+        self.pub_poses.publish(out)
+
+        if self.visualization_enable and self.pub_markers is not None:
+            self.pub_markers.publish(marker_array)
+
+    def publish_status_array(self):
+        now = self.get_clock().now()
+
+        out = ObjectEkfStatusArray()
+        out.header.stamp = now.to_msg()
+        out.header.frame_id = self.map_frame
+
+        for track in self.tracks.values():
+            out.statuses.append(track.create_status_msg(now, self.map_frame))
+
+        self.pub_status.publish(out)
+
+    def make_object_markers(self, pose_msg, marker_id_start):
+        markers = []
+
+        stamp = pose_msg.header.stamp
+        frame_id = pose_msg.header.frame_id
+
+        x = pose_msg.pose.pose.position.x
+        y = pose_msg.pose.pose.position.y
+        z = pose_msg.pose.pose.position.z
+
+        # Main object marker
+        sphere = Marker()
+        sphere.header.stamp = stamp
+        sphere.header.frame_id = frame_id
+        sphere.ns = pose_msg.class_name
+        sphere.id = marker_id_start
+        sphere.type = Marker.SPHERE
+        sphere.action = Marker.ADD
+        sphere.pose = pose_msg.pose.pose
+        sphere.scale.x = 0.35
+        sphere.scale.y = 0.35
+        sphere.scale.z = 0.35
+        sphere.color.r = 0.0
+        sphere.color.g = 1.0
+        sphere.color.b = 0.0
+        sphere.color.a = 1.0
+        markers.append(sphere)
+
+        # Text label
+        text = Marker()
+        text.header.stamp = stamp
+        text.header.frame_id = frame_id
+        text.ns = pose_msg.class_name
+        text.id = marker_id_start + 1
+        text.type = Marker.TEXT_VIEW_FACING
+        text.action = Marker.ADD
+        text.pose.position.x = x
+        text.pose.position.y = y
+        text.pose.position.z = z + 0.6
+        text.scale.z = 0.35
+        text.color.r = 1.0
+        text.color.g = 1.0
+        text.color.b = 1.0
+        text.color.a = 1.0
+        text.text = f"{pose_msg.class_name}"
+        markers.append(text)
+
+        # 2D covariance ellipse in XY
+        try:
+            cov = np.array(pose_msg.pose.covariance, dtype=float)
+            if cov.size != 36:
+                raise ValueError("covariance size is not 36")
+
+            cov = cov.reshape(6, 6)
+            cov_xy = np.nan_to_num(cov[:2, :2], nan=1e-6, posinf=1e-6, neginf=1e-6)
+            cov_xy = 0.5 * (cov_xy + cov_xy.T)
+
+            eigvals, eigvecs = np.linalg.eigh(cov_xy)
+            eigvals = np.clip(eigvals, 1e-6, None)
+
+            order = np.argsort(eigvals)[::-1]
+            eigvals = eigvals[order]
+            eigvecs = eigvecs[:, order]
+
+            major = 2.0 * math.sqrt(max(eigvals[0], 1e-6)) * 1.2
+            minor = 2.0 * math.sqrt(max(eigvals[1], 1e-6)) * 1.2
+
+            yaw = math.atan2(eigvecs[1, 0], eigvecs[0, 0])
+            q = R.from_euler("z", yaw).as_quat()
+
+            ellipse = Marker()
+            ellipse.header.stamp = stamp
+            ellipse.header.frame_id = frame_id
+            ellipse.ns = pose_msg.class_name
+            ellipse.id = marker_id_start + 2
+            ellipse.type = Marker.CYLINDER
+            ellipse.action = Marker.ADD
+
+            ellipse.pose.position.x = x
+            ellipse.pose.position.y = y
+            ellipse.pose.position.z = z + 0.02
+            ellipse.pose.orientation.x = q[0]
+            ellipse.pose.orientation.y = q[1]
+            ellipse.pose.orientation.z = q[2]
+            ellipse.pose.orientation.w = q[3]
+
+            ellipse.scale.x = major
+            ellipse.scale.y = minor
+            ellipse.scale.z = 0.03
+
+            ellipse.color.r = 1.0
+            ellipse.color.g = 1.0
+            ellipse.color.b = 0.0
+            ellipse.color.a = 0.35
+
+            markers.append(ellipse)
+
+        except Exception as e:
+            self.get_logger().warn(f"Could not create covariance marker: {e}")
+
+        # Visualize the pose orientation as an arrow
+        arrow = Marker()
+        arrow.header.stamp = stamp
+        arrow.header.frame_id = frame_id
+        arrow.ns = pose_msg.class_name
+        arrow.id = marker_id_start + 3
+        arrow.type = Marker.ARROW
+        arrow.action = Marker.ADD
+        arrow.pose.position.x = x
+        arrow.pose.position.y = y
+        arrow.pose.position.z = z
+        arrow.pose.orientation = pose_msg.pose.pose.orientation
+        arrow.scale.x = 0.6
+        arrow.scale.y = 0.08
+        arrow.scale.z = 0.08
+        arrow.color.r = 0.0
+        arrow.color.g = 0.0
+        arrow.color.b = 1.0
+        arrow.color.a = 0.9
+        markers.append(arrow)
+
+        return markers
+
+    def handle_reset(self, request, response):
+        target = request.class_name.strip()
+
+        if target == "":
+            response.success = False
+            response.message = (
+                "class_name must not be empty. "
+                "Use class_name='all' to reset all EKFs."
+            )
+            return response
+
+        if target == "all":
+            for track in self.tracks.values():
+                track.reset_filter()
+
+            response.success = True
+            response.message = "Reset all object EKFs"
+            return response
+
+        if target not in self.tracks:
+            response.success = False
+            response.message = (
+                f"Unknown class_name: {target}. "
+                f"Available classes: {list(self.tracks.keys())}"
+            )
+            return response
+
+        self.tracks[target].reset_filter()
+
+        response.success = True
+        response.message = f"Reset EKF for class_name={target}"
+        return response
+
+    def resolve_frame(self, frame):
+        frame = str(frame).strip("/")
+
+        if self.robot_name == "":
+            return frame
+
+        if frame.startswith(f"{self.robot_name}/"):
+            return frame
+
+        return f"{self.robot_name}/{frame}"
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = MultiObjectEKFNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/perception/alars/auv_state_estimation/auv_state_estimation/multi_object_ekf_node.py
+++ b/perception/alars/auv_state_estimation/auv_state_estimation/multi_object_ekf_node.py
@@ -7,7 +7,7 @@ from rclpy.node import Node
 from rclpy.time import Time
 from rclpy.duration import Duration
 
-from geometry_msgs.msg import PolygonStamped, Point
+from geometry_msgs.msg import PolygonStamped
 from nav_msgs.msg import Odometry
 from scipy.spatial.transform import Rotation as R
 import tf2_ros
@@ -33,7 +33,6 @@ class MultiObjectEKFNode(Node):
         self.declare_parameter("topics.status_array", Topics.OBJECT_EKF_STATUS_ARRAY_TOPIC)
 
         # Visualization
-        self.declare_parameter("visualization.enable", True)
         self.declare_parameter("visualization_enable", True)
         self.declare_parameter("topics.markers", Topics.OBJECT_EKF_MARKERS_TOPIC)
 
@@ -80,9 +79,7 @@ class MultiObjectEKFNode(Node):
         self.input_detections_corners_topic = self.get_parameter("topics.input_detections_corners").get_parameter_value().string_value
         self.output_poses_array_topic = self.get_parameter("topics.output_poses_array").get_parameter_value().string_value
         self.status_array_topic = self.get_parameter("topics.status_array").get_parameter_value().string_value
-        flat_visualization_enabled = self.get_parameter("visualization_enable").get_parameter_value().bool_value
-        nested_visualization_enabled = self.get_parameter("visualization.enable").get_parameter_value().bool_value
-        self.visualization_enable = bool(flat_visualization_enabled and nested_visualization_enabled)
+        self.visualization_enable = self.get_parameter("visualization_enable").get_parameter_value().bool_value
         self.markers_topic = self.get_parameter("topics.markers").get_parameter_value().string_value
         self.reset_service_name = self.get_parameter("services.reset").get_parameter_value().string_value
         self.odom_topic = self.get_parameter("topics.odom").get_parameter_value().string_value

--- a/perception/alars/auv_state_estimation/auv_state_estimation/object_ekf.py
+++ b/perception/alars/auv_state_estimation/auv_state_estimation/object_ekf.py
@@ -1,0 +1,581 @@
+import numpy as np
+
+from rclpy.time import Time
+from scipy.stats import chi2
+from scipy.spatial.transform import Rotation as R
+
+from dji_msgs.msg import ObjectPoseWithCovariance, ObjectEkfStatus
+
+from .ekf_core import EKFCore
+from .measurement_model import MeasurementModel
+from .noise_models import NoiseModels
+from .initializer import Initializer
+from .visualization import create_pose_msg
+from .geometry_utils import residual_z, wrap
+from .motion_model import DepthModel, DoubleOscillatorModel, OscillatorModel, PitchModel, SurfaceModel, PitchModel
+
+class ObjectEKF:
+    """
+    Single-object EKF logic.
+    """
+
+    def __init__(self, class_name, cfg, base_params, camera_info, logger):
+        self.class_name = class_name
+        self.logger = logger
+
+        if self.class_name == "":
+            raise ValueError("class_name must not be empty")
+
+        self.get_params(cfg, base_params, camera_info)
+
+        self.log_info(f"Object/class name: {self.class_name}")
+        self.log_info(f"Motion model type: {self.motion_model_type}")
+
+        self.motion_model = self.get_motion_model(self.motion_model_type)
+        self.eps = self.motion_model.eps
+
+        self.state_dim = self.motion_model.state_dim
+        self.meas_dim = 3 if self.state_dim == 5 else 5
+        self.outlier_threshold = chi2.ppf(self.gating_prob, df=self.meas_dim)
+
+        # In case of AUV estimation, we can optionally use a head topic.
+        # For generic multi-object estimation this is disabled for now.
+        self.enable_head_disambiguation = False
+        self.flip_buffer = [-1]
+
+        self.current_cam_pos_map = None
+        self.current_R_map_cam = None
+        self.lin_vel_map = np.zeros(3)
+        self.ang_vel_map = np.zeros(3)
+
+        self.last_processed_measurement_time = None
+        self.last_innovation_norm = -1.0
+        self.nr_of_consecutive_invalid_measurements = 0
+
+        self.initialize_components()
+
+        self.log_info(
+            f"Created EKF for class={self.class_name}, "
+            f"model={self.motion_model_type}, "
+            f"size={self.obb_length_m}x{self.obb_width_m}"
+        )
+
+    @staticmethod
+    def flatten_params(params, prefix=""):
+        flat = {}
+
+        for key, value in params.items():
+            full_key = f"{prefix}.{key}" if prefix else key
+
+            if isinstance(value, dict):
+                flat.update(ObjectEKF.flatten_params(value, full_key))
+            else:
+                flat[full_key] = value
+
+        return flat
+
+    def log_info(self, msg):
+        if self.logger_info_enable:
+            self.logger.info(msg)
+
+    def matches_detection(self, det):
+        return str(det.class_name) == self.class_name
+
+    def pol_to_array(self, msg):
+        # polygon -> array of normalized image coordinates
+        return np.array([(p.x, p.y) for p in msg.polygon.points])
+
+    def z(self, msg, cam_pos_map, R_map_cam, lin_vel_map, ang_vel_map, now):
+        # main callback for processing incoming measurements, performing EKF prediction and update, and preparing the estimated pose.
+        stamp = msg.header.stamp
+        t: float = stamp.sec + stamp.nanosec * 1e-9
+
+        self.current_cam_pos_map = cam_pos_map
+        self.current_R_map_cam = R_map_cam
+        self.lin_vel_map = lin_vel_map
+        self.ang_vel_map = ang_vel_map
+
+        if Time.from_msg(stamp).seconds_nanoseconds() == (0, 0):
+            self.log_info(f"{self.class_name}: Received message with zero timestamp, skipping.")
+            return
+
+        if self.last_processed_measurement_time is not None:
+            state_age = (now - self.last_processed_measurement_time).nanoseconds * 1e-9
+            if state_age > self.stale_state_age:
+                self.log_info(f"{self.class_name}: Exceeding stale state age {state_age:.2f}s, Resetting filter.")
+                self.reset_filter()
+                return
+        else:
+            self.log_info(f"{self.class_name}: First measurement received.")
+
+        z_center_img, z_alpha_img, z_len_px, z_wid_px, _ = self.measurement_model.extract_features(self.pol_to_array(msg))
+
+        if not self.ekf.initialized:
+            init_result = self.initializer.try_initialize(stamp, z_center_img, z_alpha_img, self.measurement_model, self.current_cam_pos_map, self.current_R_map_cam)
+            if init_result is None:
+                return
+
+            X0, P0, t0 = init_result
+            self.ekf.set_state(X0, P0, t0)
+            self.ekf.initialized = True
+            self.last_processed_measurement_time = now
+            self.log_info(f"{self.class_name}: Initialization complete")
+            return
+
+        if self.state_dim == 5:
+            z = np.array([[z_center_img[0]], [z_center_img[1]], [z_alpha_img]])
+        else:
+            z = np.array([[z_center_img[0]], [z_center_img[1]], [z_alpha_img], [z_len_px], [z_wid_px]])
+
+        if self.ekf.last_t is None:
+            self.log_info(f"{self.class_name}: EKF not initialized with time, skipping measurement")
+            return
+
+        dt: float = t - self.ekf.last_t
+
+        if dt < 0:  # due to mismatch between stamp and arrival time, we may receive measurements from the past.
+            self.log_info(f"{self.class_name}: Measurement from the past received (dt={dt:.3f}s), skipping")
+            return
+
+        X = self.predict_to_measurement_time(dt)
+
+        h = self.measurement_model.hx(X, cam_pos_map=self.current_cam_pos_map, R_map_cam=self.current_R_map_cam)
+        if h is None:
+            self.nr_of_consecutive_invalid_measurements += 1
+            self.log_info(f"{self.class_name}: Measurement function returned None, skipping update")
+            return
+
+        H = self.measurement_model.numerical_H(X, cam_pos_map=self.current_cam_pos_map, R_map_cam=self.current_R_map_cam)
+        J_pose = self.measurement_model.numerical_J_pose(X, cam_pos_map=self.current_cam_pos_map, R_map_cam=self.current_R_map_cam)
+        R_meas = self.noise_models.build_image_measurement_covariance(z_center_img, self.lin_vel_map) + self.noise_models.project_pose_covariance_to_measurement(J_pose, self.lin_vel_map, self.ang_vel_map)
+
+        innov = residual_z(z, h).reshape(z.shape[0], 1)
+        self.last_innovation_norm = np.linalg.norm(innov)
+
+        X, P, status = self.ekf.update(z, h, H, R_meas)
+
+        if status == "outlier" or status == "invalid":
+            self.nr_of_consecutive_invalid_measurements += 1
+        elif status == "updated":
+            self.nr_of_consecutive_invalid_measurements = 0
+
+        self.last_processed_measurement_time = now
+        self.log_info(f"{self.class_name}: update {status}, state={X.flatten()[:3]}")
+
+    def predict_to_measurement_time(self, dt_total):
+        # performs multiple prediction steps between measurements.
+        # this improves predictions during longer time gaps.
+
+        dt_max = 0.01
+        n_steps = max(1, int(np.ceil(dt_total / dt_max)))
+        dt_step = dt_total / n_steps
+
+        for _ in range(n_steps):
+            X, F = self.motion_model.predict(self.ekf.X, dt_step)
+            Q = self.motion_model.build_Q(dt_step)
+            self.ekf.predict(X, F, Q, self.ekf.last_t + dt_step)
+        return X # type: ignore
+
+    def create_estimate_msg(self, stamp, map_frame):
+        # creates the current state estimate as an ObjectPoseWithCovariance message.
+        yaw_idx = 2 if self.state_dim == 5 else 3
+
+        if not self.ekf.initialized:
+            return None
+
+        yaw_out = self.ekf.X[yaw_idx, 0]
+
+        if self.enable_head_disambiguation:
+            flip_decision = np.sum(self.flip_buffer)
+
+            if flip_decision > 0:
+                yaw_out += np.pi
+
+        yaw_out = wrap(yaw_out)
+
+        if self.state_dim == 5:
+            q = R.from_euler("z", yaw_out).as_quat()
+        elif self.motion_model_type == "pitch":
+            q = R.from_euler("xyz", [0, self.ekf.X[4, 0], yaw_out]).as_quat()
+        else:
+            q = R.from_euler("z", yaw_out).as_quat()
+
+        if Time.from_msg(stamp).seconds_nanoseconds() == (0, 0):
+            self.log_info(">> Almost created estimate without a stamp!")
+            return None
+
+        pose_stamped = create_pose_msg(stamp, self.motion_model_type, q, map_frame, self.ekf.X, self.ekf.P, self.water_surface_height)
+
+        out = ObjectPoseWithCovariance()
+        out.header = pose_stamped.header
+        out.class_name = self.class_name
+        out.pose = pose_stamped.pose
+
+        return out
+
+    def create_status_msg(self, now, map_frame):
+        # creates information regarding the status of the filter.
+        # nr of consecutive outliers is probably a good indication of the status.
+        now_sec = now.nanoseconds * 1e-9
+
+        if self.ekf.initialized:
+            time_since_last_update = now_sec - self.ekf.time_last_update
+
+            if time_since_last_update > self.stale_state_age:
+                self.log_info(
+                    f"{self.class_name}: time since last update is "
+                    f"{time_since_last_update:.3f}s, exceeding stale state age "
+                    f"{self.stale_state_age}s. Resetting filter."
+                )
+                self.reset_filter()
+        else:
+            time_since_last_update = 0.0
+
+        msg = ObjectEkfStatus()
+        msg.header.stamp = now.to_msg()
+        msg.header.frame_id = map_frame
+
+        msg.class_name = self.class_name
+
+        msg.initialized = bool(self.ekf.initialized)
+
+        if self.last_processed_measurement_time is None:
+            msg.time_since_last_processed_measurement = 0.0
+        else:
+            msg.time_since_last_processed_measurement = float((now - self.last_processed_measurement_time).nanoseconds * 1e-9)
+
+        msg.time_since_last_update = float(time_since_last_update)
+        msg.consecutive_outliers = int(self.ekf.nr_of_consecutive_outliers)
+        msg.consecutive_invalid_measurements = int(self.nr_of_consecutive_invalid_measurements)
+        msg.covariance_trace = float(np.trace(self.ekf.P) if self.ekf.P is not None else -1.0)
+        msg.innovation_norm = float(self.last_innovation_norm)
+
+        return msg
+
+    def reset_filter(self):
+        self.ekf = EKFCore(
+            self.water_surface_height,
+            state_dim=self.state_dim,
+            outlier_threshold=self.outlier_threshold,
+            logger=self.logger,
+        )
+
+        self.flip_buffer = [-1]
+        self.current_cam_pos_map = None
+        self.current_R_map_cam = None
+        self.lin_vel_map = np.zeros(3)
+        self.ang_vel_map = np.zeros(3)
+        self.last_processed_measurement_time = None
+        self.nr_of_consecutive_invalid_measurements = 0
+        self.last_innovation_norm = -1.0
+
+        self.logger.info(f"{self.class_name}: EKF internal state reset.")
+
+    def get_motion_model(self, model_type):
+        if model_type == "surface":
+            return SurfaceModel(
+                sigma_a=self.sigma_a_xy,
+                sigma_yaw=self.sigma_yaw,
+            )
+
+        elif model_type == "depth":
+            return DepthModel(
+                sigma_a=self.sigma_a_xy,
+                sigma_z=self.depth_sigma_z_process,
+                sigma_yaw=self.sigma_yaw,
+            )
+
+        elif model_type == "pitch":
+            return PitchModel(
+                sigma_a=self.sigma_a_xy,
+                sigma_z=self.depth_sigma_z_process,
+                sigma_yaw=self.sigma_yaw,
+                sigma_pitch=self.sigma_pitch_process,
+            )
+
+        elif model_type == "oscillator":
+            return OscillatorModel(
+                sigma_a=self.sigma_a_xy,
+                sigma_z=self.oscillator_sigma_z_process,
+                sigma_yaw=self.sigma_yaw,
+                omega=self.oscillator_omega,
+                zeta=self.oscillator_zeta,
+            )
+
+        elif model_type == "double_oscillator":
+            return DoubleOscillatorModel(
+                sigma_a=self.sigma_a_xy,
+                sigma_z_slow=self.double_oscillator_sigma_z_slow,
+                sigma_z_fast=self.double_oscillator_sigma_z_fast,
+                sigma_yaw=self.sigma_yaw,
+                omega_slow=self.double_oscillator_omega_slow,
+                zeta_slow=self.double_oscillator_zeta_slow,
+                omega_fast=self.double_oscillator_omega_fast,
+                zeta_fast=self.double_oscillator_zeta_fast,
+            )
+        else:
+            raise ValueError(f"Unknown motion model type: {model_type}")
+
+    def initialize_components(self):
+        self.initializer = Initializer(
+            z_water=self.water_surface_height,
+            state_dim=self.state_dim,
+            init_z_needed=self.init_z_needed,
+            init_pos_max_spread=self.init_pos_max_spread,
+            init_yaw_max_spread=self.init_yaw_max_spread,
+            alpha_line_pixels=self.alpha_line_pixels,
+            R_len=self.R_len,
+            R_wid=self.R_wid,
+            R_alpha=self.R_alpha,
+            motion_model_type=self.motion_model_type,
+            logger=self.logger,
+        )
+        self.measurement_model = MeasurementModel(
+            meas_dim=self.meas_dim,
+            state_dim=self.state_dim,
+            eps=self.eps,
+            eps_pose_pos=self.eps_pose_pos,
+            eps_pose_ang=self.eps_pose_ang,
+            width=self.width,
+            height=self.height,
+            K=self.K,
+            D=self.D,
+            z_water=self.water_surface_height,
+            obb_length_m=self.obb_length_m,
+            obb_width_m=self.obb_width_m,
+            motion_model_type=self.motion_model_type,
+            logger=self.logger,
+        )
+        self.noise_models = NoiseModels(
+            width=self.width,
+            height=self.height,
+            R_u=self.R_u,
+            R_v=self.R_v,
+            R_alpha=self.R_alpha,
+            R_len=self.R_len,
+            R_wid=self.R_wid,
+            R_pose_x=self.R_pose_x,
+            R_pose_y=self.R_pose_y,
+            R_pose_z=self.R_pose_z,
+            R_pose_r=self.R_pose_r,
+            R_pose_p=self.R_pose_p,
+            R_pose_yaw=self.R_pose_yaw,
+            R_dyn_center_gain_u=self.R_dyn_center_gain_u,
+            R_dyn_center_gain_v=self.R_dyn_center_gain_v,
+            R_dyn_center_gain_alpha=self.R_dyn_center_gain_alpha,
+            R_dyn_center_gain_len=self.R_dyn_center_gain_len,
+            R_dyn_center_gain_wid=self.R_dyn_center_gain_wid,
+            R_dyn_speed_gain_u=self.R_dyn_speed_gain_u,
+            R_dyn_speed_gain_v=self.R_dyn_speed_gain_v,
+            R_dyn_speed_gain_alpha=self.R_dyn_speed_gain_alpha,
+            R_dyn_speed_gain_len=self.R_dyn_speed_gain_len,
+            R_dyn_speed_gain_wid=self.R_dyn_speed_gain_wid,
+            R_dyn_dt=self.R_dyn_dt,
+            meas_dim=self.meas_dim,
+        )
+        self.ekf = EKFCore(
+            self.water_surface_height,
+            state_dim=self.state_dim,
+            outlier_threshold=self.outlier_threshold,
+            logger=self.logger,
+        )
+
+    def get_params(self, cfg, base_params, camera_info):
+        PARAMS = [
+            ("object_name", "object"),
+
+            ("detection.class_name", ""),
+            ("detection.confidence_threshold", 0.5),
+
+            ("environment.water_surface_height", 0.0),
+
+            # Dimensions of the object model used by the measurement model.
+            ("obb.length_m", 1.3),
+            ("obb.width_m", 0.16),
+
+            ("alpha_line_pixels", 40), # pixels along the alpha direction to compute the front and back rays for yaw estimation in initialization
+
+            ("motion.sigma_a_xy", 0.01), # m/s^2, could split up into x, y
+            ("motion.sigma_yaw", 3.0), # deg/s
+            ("motion.model_type", "double_oscillator"),
+
+            ("depth.sigma_z_process", 1.0),
+            ("depth.k_z", 0.4),
+            ("depth.d_z", 0.1),
+
+            ("pitch.sigma_pitch_process", 15.0),
+
+            ("oscillator.sigma_z_process", 5.0),
+            ("oscillator.omega", 2.0),
+            ("oscillator.zeta", 0.01),
+
+            ("double_oscillator.sigma_z_slow", 1.0),
+            ("double_oscillator.sigma_z_fast", 3.0),
+            ("double_oscillator.omega_slow", 1.0),
+            ("double_oscillator.zeta_slow", 0.01),
+            ("double_oscillator.omega_fast", 2.0),
+            ("double_oscillator.zeta_fast", 0.01),
+
+            # measurement noise stddev (pixels)
+            ("measurement_noise.R_u", 10.0),
+            ("measurement_noise.R_v", 10.0),
+            ("measurement_noise.R_alpha_deg", 5.0),
+            ("measurement_noise.R_len", 200.0),
+            ("measurement_noise.R_wid", 40.0),
+
+            # dynamic measurement noise stddev (pixels)
+            # increases with distance from image center
+            ("measurement_noise.center_gain_u", 50.0),
+            ("measurement_noise.center_gain_v", 50.0),
+            ("measurement_noise.center_gain_alpha_deg", 10.0),
+            ("measurement_noise.center_gain_len", 10.0),
+            ("measurement_noise.center_gain_wid", 10.0),
+
+            # increases with drone speed
+            ("measurement_noise.speed_gain_u", 50.0),
+            ("measurement_noise.speed_gain_v", 50.0),
+            ("measurement_noise.speed_gain_alpha_deg", 10.0),
+            ("measurement_noise.speed_gain_len", 60.0),
+            ("measurement_noise.speed_gain_wid", 30.0),
+
+            ("measurement_noise.R_dyn_dt", 0.5),
+
+            # drone pose noise
+            ("camera_pose_noise.R_pose_x", 0.03),
+            ("camera_pose_noise.R_pose_y", 0.03),
+            ("camera_pose_noise.R_pose_z", 0.03),
+            ("camera_pose_noise.R_pose_r", 1.0),
+            ("camera_pose_noise.R_pose_p", 1.0),
+            ("camera_pose_noise.R_pose_yaw", 3.0),
+
+            # dynamic measurement noise update rate (s)
+
+            ("initialization.min_valid_meas_needed", 5),
+            ("initialization.max_pos_spread", 2.0),
+            ("initialization.max_yaw_spread", 0.7),
+
+            ("gating.prob", 0.99),
+
+            # jacobian epsilons for numerical differentiation
+            ("jacobian.eps_state_pos", 1e-3),
+            ("jacobian.eps_state_yaw", 1e-3),
+            ("jacobian.eps_state_vel", 1e-3),
+            ("jacobian.eps_pose_pos", 1e-3),
+            ("jacobian.eps_pose_ang", 1e-3),
+
+            ("logger_info.enable", True),
+
+            # if the state is older than this many seconds when a new measurement arrives, reset the filter.
+            ("stale_state_age", 3.0),
+        ]
+
+        params = dict(PARAMS)
+
+        # Base params are loaded from the common EKF yaml file.
+        params.update(base_params)
+
+        # Per-class params override the base params.
+        params.update(self.flatten_params(cfg.get("parameters", {})))
+
+        # Per-class top-level config values.
+        params["object_name"] = self.class_name
+        params["detection.class_name"] = self.class_name
+        params["detection.confidence_threshold"] = cfg.get(
+            "confidence_threshold",
+            params["detection.confidence_threshold"],
+        )
+        params["obb.length_m"] = cfg.get("length_m", params["obb.length_m"])
+        params["obb.width_m"] = cfg.get("width_m", params["obb.width_m"])
+        params["motion.model_type"] = cfg.get(
+            "motion_model_type",
+            params["motion.model_type"],
+        )
+
+        env = cfg.get("environment", {})
+        params["environment.water_surface_height"] = env.get(
+            "water_surface_height",
+            params["environment.water_surface_height"],
+        )
+
+        self.params = params
+
+        self.object_name: str = str(params["object_name"])
+        self.detection_class_name: str = str(params["detection.class_name"])
+        self.confidence_threshold: float = float(params["detection.confidence_threshold"])
+
+        self.water_surface_height: float = float(params["environment.water_surface_height"])
+
+        self.obb_length_m: float = float(params["obb.length_m"])
+        self.obb_width_m: float = float(params["obb.width_m"])
+        self.alpha_line_pixels: int = int(params["alpha_line_pixels"])
+
+        self.sigma_a_xy: float = float(params["motion.sigma_a_xy"])
+        self.sigma_yaw: float = np.deg2rad(float(params["motion.sigma_yaw"]))
+
+        self.motion_model_type: str = str(params["motion.model_type"])
+
+        self.depth_sigma_z_process: float = float(params["depth.sigma_z_process"])
+        self.depth_k_z: float = float(params["depth.k_z"])
+        self.depth_d_z: float = float(params["depth.d_z"])
+
+        self.sigma_pitch_process: float = float(params["pitch.sigma_pitch_process"])
+
+        self.oscillator_sigma_z_process: float = float(params["oscillator.sigma_z_process"])
+        self.oscillator_omega: float = float(params["oscillator.omega"])
+        self.oscillator_zeta: float = float(params["oscillator.zeta"])
+
+        self.double_oscillator_sigma_z_slow: float = float(params["double_oscillator.sigma_z_slow"])
+        self.double_oscillator_sigma_z_fast: float = float(params["double_oscillator.sigma_z_fast"])
+        self.double_oscillator_omega_slow: float = float(params["double_oscillator.omega_slow"])
+        self.double_oscillator_zeta_slow: float = float(params["double_oscillator.zeta_slow"])
+        self.double_oscillator_omega_fast: float = float(params["double_oscillator.omega_fast"])
+        self.double_oscillator_zeta_fast: float = float(params["double_oscillator.zeta_fast"])
+
+        self.R_u: float = float(params["measurement_noise.R_u"])
+        self.R_v: float = float(params["measurement_noise.R_v"])
+        self.R_alpha: float = np.deg2rad(float(params["measurement_noise.R_alpha_deg"]))
+        self.R_len: float = float(params["measurement_noise.R_len"])
+        self.R_wid: float = float(params["measurement_noise.R_wid"])
+
+        self.R_pose_x: float = float(params["camera_pose_noise.R_pose_x"])
+        self.R_pose_y: float = float(params["camera_pose_noise.R_pose_y"])
+        self.R_pose_z: float = float(params["camera_pose_noise.R_pose_z"])
+        self.R_pose_r: float = np.deg2rad(float(params["camera_pose_noise.R_pose_r"]))
+        self.R_pose_p: float = np.deg2rad(float(params["camera_pose_noise.R_pose_p"]))
+        self.R_pose_yaw: float = np.deg2rad(float(params["camera_pose_noise.R_pose_yaw"]))
+
+        self.R_dyn_center_gain_u: float = float(params["measurement_noise.center_gain_u"])
+        self.R_dyn_center_gain_v: float = float(params["measurement_noise.center_gain_v"])
+        self.R_dyn_center_gain_alpha: float = np.deg2rad(float(params["measurement_noise.center_gain_alpha_deg"]))
+        self.R_dyn_center_gain_len: float = float(params["measurement_noise.center_gain_len"])
+        self.R_dyn_center_gain_wid: float = float(params["measurement_noise.center_gain_wid"])
+
+        self.R_dyn_speed_gain_u: float = float(params["measurement_noise.speed_gain_u"])
+        self.R_dyn_speed_gain_v: float = float(params["measurement_noise.speed_gain_v"])
+        self.R_dyn_speed_gain_alpha: float = np.deg2rad(float(params["measurement_noise.speed_gain_alpha_deg"]))
+        self.R_dyn_speed_gain_len: float = float(params["measurement_noise.speed_gain_len"])
+        self.R_dyn_speed_gain_wid: float = float(params["measurement_noise.speed_gain_wid"])
+
+        self.R_dyn_dt: float = float(params["measurement_noise.R_dyn_dt"])
+
+        self.init_z_needed: int = int(params["initialization.min_valid_meas_needed"])
+        self.init_pos_max_spread: float = float(params["initialization.max_pos_spread"])
+        self.init_yaw_max_spread: float = np.deg2rad(float(params["initialization.max_yaw_spread"]))
+
+        self.gating_prob: float = float(params["gating.prob"])
+
+        self.eps_state_pos: float = float(params["jacobian.eps_state_pos"])
+        self.eps_state_yaw: float = float(params["jacobian.eps_state_yaw"])
+        self.eps_state_vel: float = float(params["jacobian.eps_state_vel"])
+        self.eps_pose_pos: float = float(params["jacobian.eps_pose_pos"])
+        self.eps_pose_ang: float = float(params["jacobian.eps_pose_ang"])
+
+        self.logger_info_enable: bool = bool(params["logger_info.enable"])
+
+        # how long do we hold on to the state after last measurement before considering it stale and reinitializing?
+        self.stale_state_age: float = float(params["stale_state_age"])
+
+        self.width = camera_info["width"]
+        self.height = camera_info["height"]
+        self.K = camera_info["K"]
+        self.D = camera_info["D"]

--- a/perception/alars/auv_state_estimation/auv_state_estimation/object_ekf.py
+++ b/perception/alars/auv_state_estimation/auv_state_estimation/object_ekf.py
@@ -12,7 +12,7 @@ from .noise_models import NoiseModels
 from .initializer import Initializer
 from .visualization import create_pose_msg
 from .geometry_utils import residual_z, wrap
-from .motion_model import DepthModel, DoubleOscillatorModel, OscillatorModel, PitchModel, SurfaceModel, PitchModel
+from .motion_model import DepthModel, DoubleOscillatorModel, OscillatorModel, PitchModel, SurfaceModel
 
 class ObjectEKF:
     """
@@ -490,6 +490,8 @@ class ObjectEKF:
             "motion_model_type",
             params["motion.model_type"],
         )
+
+        params["stale_state_age"] = cfg.get("stale_state_age", params["stale_state_age"])
 
         env = cfg.get("environment", {})
         params["environment.water_surface_height"] = env.get(

--- a/perception/alars/auv_state_estimation/config/ekf_params.yaml
+++ b/perception/alars/auv_state_estimation/config/ekf_params.yaml
@@ -84,5 +84,4 @@
       enable: true
 
     enable_head_disambiguation: false
-    reset_service: ""
     stale_state_age: 3.0

--- a/perception/alars/auv_state_estimation/config/ekf_params.yaml
+++ b/perception/alars/auv_state_estimation/config/ekf_params.yaml
@@ -1,19 +1,5 @@
 /**:
   ros__parameters:
-    topics:
-      input_polygon: "estimated_auv_obb"
-      input_auv_head: "estimated_auv_head"
-      output_topic: "rviz/estimated_pose"
-      odom: "smarc/odom"
-      ekf_status: "alars_auv_ekf/status"
-
-    frames:
-      map: "map"
-      output_link: "estimated_auv"
-      camera: "z1_optical_frame"
-
-    camera_info: ""
-
     environment:
       water_surface_height: 0.0 # height of water surface in map frame.
     
@@ -97,4 +83,6 @@
     logger_info:
       enable: true
 
+    enable_head_disambiguation: false
+    reset_service: ""
     stale_state_age: 3.0

--- a/perception/alars/auv_state_estimation/config/object_estimation.yaml
+++ b/perception/alars/auv_state_estimation/config/object_estimation.yaml
@@ -15,8 +15,6 @@
         environment:
           water_surface_height: 0.0
 
-        enable_head_disambiguation: false
-
         parameters:
           motion:
             sigma_a_xy: 0.03

--- a/perception/alars/auv_state_estimation/config/object_estimation.yaml
+++ b/perception/alars/auv_state_estimation/config/object_estimation.yaml
@@ -1,0 +1,44 @@
+# This file contains the configuration for the object estimation EKF nodes. 
+# In case to estimate a new object, it should be added here with its parameters.
+/**:
+  ros__parameters:
+    classes:
+      sam:
+        enabled: true
+        confidence_threshold: 0.5
+
+        length_m: 1.3
+        width_m: 0.16
+        motion_model_type: "double_oscillator"
+        stale_state_age: 3.0
+
+        environment:
+          water_surface_height: 0.0
+
+        enable_head_disambiguation: false
+
+        parameters:
+          motion:
+            sigma_a_xy: 0.03
+          measurement_noise:
+            R_len: 100.0
+            R_wid: 40.0
+
+      buoy:
+        enabled: true
+        confidence_threshold: 0.5
+
+        length_m: 0.27
+        width_m: 0.09
+        motion_model_type: "surface"
+        stale_state_age: 10.0
+        
+        environment:
+          water_surface_height: 0.0
+
+        parameters:
+          motion:
+            sigma_a_xy: 0.01
+          measurement_noise:
+            R_len: 80.0
+            R_wid: 40.0

--- a/perception/alars/auv_state_estimation/launch/multi_ekf_launch.py
+++ b/perception/alars/auv_state_estimation/launch/multi_ekf_launch.py
@@ -1,0 +1,108 @@
+import os
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, LogInfo
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+from dji_msgs.msg import Links, Topics
+from smarc_msgs.msg import Topics as SmarcTopics
+
+
+def generate_launch_description():
+    robot_name = LaunchConfiguration("robot_name")
+
+    use_sim_time = ParameterValue(LaunchConfiguration("use_sim_time"), value_type=bool)
+
+    visualization_enable = ParameterValue(LaunchConfiguration("visualization_enable"), value_type=bool)
+
+    config_dir = LaunchConfiguration("config_dir")
+
+    base_params_file = PathJoinSubstitution([config_dir, LaunchConfiguration("base_params_file")])
+
+    object_config_file = PathJoinSubstitution([config_dir, LaunchConfiguration("object_config_file")])
+
+    camera_calibration_file = PathJoinSubstitution([config_dir, LaunchConfiguration("camera_calibration_file")])
+
+    yolo_detections_corners_topic = LaunchConfiguration("yolo_detections_corners_topic")
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "robot_name",
+                default_value="M350",
+            ),
+            DeclareLaunchArgument(
+                "use_sim_time",
+                default_value="false",
+            ),
+            DeclareLaunchArgument(
+                "visualization_enable",
+                default_value="true",
+            ),
+            DeclareLaunchArgument(
+                "config_dir",
+                default_value=PathJoinSubstitution(
+                    [
+                        FindPackageShare("auv_state_estimation"),
+                        "config",
+                    ]
+                ),
+            ),
+            DeclareLaunchArgument(
+                "base_params_file",
+                default_value="ekf_params.yaml",
+            ),
+            DeclareLaunchArgument(
+                "object_config_file",
+                default_value="object_estimation.yaml",
+            ),
+            DeclareLaunchArgument(
+                "camera_calibration_file",
+                default_value="cam_params.yaml",
+            ),
+            DeclareLaunchArgument(
+                "yolo_detections_corners_topic",
+                default_value="yolo/detections_with_corners",
+            ),
+
+            LogInfo(msg=["[multi_ekf_launch] base params file = ", base_params_file]),
+            LogInfo(msg=["[multi_ekf_launch] object config file = ", object_config_file]),
+            LogInfo(msg=["[multi_ekf_launch] camera calibration file = ", camera_calibration_file]),
+
+            Node(
+                package="auv_state_estimation",
+                executable="multi_object_ekf_node",
+                namespace=robot_name,
+                name="multi_object_ekf_node",
+                output="screen",
+                parameters=[
+                    {
+                        "robot_name": robot_name,
+                        "use_sim_time": use_sim_time,
+
+                        "base_params_file": base_params_file,
+                        "object_config_file": object_config_file,
+                        "camera_info": camera_calibration_file,
+
+                        "topics.input_detections_corners": yolo_detections_corners_topic,
+                        "topics.odom": SmarcTopics.ODOM_TOPIC,
+
+                        "topics.output_poses_array": Topics.PROJECTED_OBJECT_POSES_ARRAY_TOPIC,
+                        "topics.status_array": Topics.OBJECT_EKF_STATUS_ARRAY_TOPIC,
+
+                        "visualization.enable": visualization_enable,
+                        "topics.markers": Topics.OBJECT_EKF_MARKERS_TOPIC,
+
+                        "services.reset": Topics.OBJECT_EKF_RESET_SERVICE,
+
+                        "frames.map": Links.MAP,
+                        "frames.camera": Links.GIMBAL_OPTICAL_FRAME,
+                    }
+                ],
+            ),
+        ]
+    )

--- a/perception/alars/auv_state_estimation/launch/multi_ekf_launch.py
+++ b/perception/alars/auv_state_estimation/launch/multi_ekf_launch.py
@@ -94,7 +94,7 @@ def generate_launch_description():
                         "topics.output_poses_array": Topics.PROJECTED_OBJECT_POSES_ARRAY_TOPIC,
                         "topics.status_array": Topics.OBJECT_EKF_STATUS_ARRAY_TOPIC,
 
-                        "visualization.enable": visualization_enable,
+                        "visualization_enable": visualization_enable,
                         "topics.markers": Topics.OBJECT_EKF_MARKERS_TOPIC,
 
                         "services.reset": Topics.OBJECT_EKF_RESET_SERVICE,

--- a/perception/alars/auv_state_estimation/package.xml
+++ b/perception/alars/auv_state_estimation/package.xml
@@ -9,6 +9,7 @@
 
   <depend>rclpy</depend>
   <depend>geometry_msgs</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/perception/alars/auv_state_estimation/setup.py
+++ b/perception/alars/auv_state_estimation/setup.py
@@ -20,8 +20,8 @@ setup(
     zip_safe=True,
     maintainer='sebbe',
     maintainer_email='sebbe@todo.todo',
-    description='TODO: Package description',
-    license='TODO: License declaration',
+    description='ROS2 package for ALARS state estimation',
+    license='MIT',
     extras_require={
         'test': [
             'pytest',
@@ -30,7 +30,7 @@ setup(
     entry_points={
         'console_scripts': [
             'projection = auv_state_estimation.projection:main',
-            'ekf_node = auv_state_estimation.ekf_node:main',
+            'multi_object_ekf_node = auv_state_estimation.multi_object_ekf_node:main',
         ],
     },
 )

--- a/scripts/smarc_bringups/scripts/dji_bringup.sh
+++ b/scripts/smarc_bringups/scripts/dji_bringup.sh
@@ -254,29 +254,38 @@ if [[ "$NO_CAM" == "True" ]]; then
     PROJECTION_CMD="echo 'Camera disabled, not launching projection node'"
 else
     YOLO_DEVICE=0
+    YOLO_THRESHOLD=0.5
+    YOLO_ENABLE=True
+    
     CAM_CALIBRATION_FILE="z1_720p_cam_params.yaml"
     YOLO_MODEL="yolo_model_2cls_may.pt" # Options: alars_labeling_training/trained_models
+    OBJECT_CONFIG_FILE="object_estimation.yaml" # Config file to edit each object's parameters for the EKF 
+    MARKERS_VISUALIZATION_ENABLE=True # Only used for debugging, since we cannot visualize new custom array for the poses in RViz
+    
     if [[ $USE_SIM_TIME = "True" ]]; then
         YOLO_DEVICE=cpu
         CAM_CALIBRATION_FILE="sim_1080p_cam_params.yaml"
         # seems to be doing better in sim
         YOLO_MODEL="yolo_model_2cls_mixed.pt"
     fi
-    YOLO_CMD="ros2 launch alars_auv_perception alars_yolo_detector.launch.py \
-    robot_name:=$ROBOT_NAME \
-    device:=$YOLO_DEVICE \
-    use_sim_time:=$USE_SIM_TIME \
-    model_package:=alars_labeling_training \
-    model_file:=$YOLO_MODEL"
 
-    PROJECTION_CMD="ros2 launch auv_state_estimation auv_buoy_ekf_launch.py \
+    YOLO_CMD="ros2 launch yolo_smarc_actions alars_yolo_corners.launch.py \
+    robot_name:=$ROBOT_NAME \
+    model_package:=alars_labeling_training \
+    model_subdir:=trained_models \
+    model_file:=$YOLO_MODEL \
+    namespace:=$ROBOT_NAME/yolo \
+    device:=$YOLO_DEVICE \
+    threshold:=$YOLO_THRESHOLD \
+    enable:=$YOLO_ENABLE
+    "
+
+    PROJECTION_CMD="ros2 launch auv_state_estimation multi_ekf_launch.py \
     robot_name:=$ROBOT_NAME \
     use_sim_time:=$USE_SIM_TIME \
     camera_calibration_file:=$CAM_CALIBRATION_FILE \
-    auv_ekf_staleness_seconds:=$EKF_STALENESS_SECONDS \
-    buoy_ekf_staleness_seconds:=10.0 \
-    auv_length_m:=$AUV_LENGTH_M \
-    auv_width_m:=$AUV_WIDTH_M
+    object_config_file:=$OBJECT_CONFIG_FILE \
+    visualization_enable:=$MARKERS_VISUALIZATION_ENABLE
     "
 fi
 


### PR DESCRIPTION
Update the ALARS perception and estimation pipeline to make object estimation more flexible and configurable. Any detected object can now be estimated if it is defined in the configuration file, and the pipeline now uses the updated `yolo_ros` submodule launch setup.

Changes

- Add new object EKF ROS interfaces:
  - object EKF status messages
  - object pose with covariance messages
  - array messages for multiple object estimates
  - reset service for object EKF state

- Add configurable multi-object EKF estimation:
  - new base object EKF implementation (based on 'ekf_node')
  - new multi-object EKF node that can handle different object classes
  - update `ekf_params.yaml` as generic parameter structure
  - support for object-specific parameters through `object_estimation.yaml`
  - add a new multi-object EKF launch file

- Update `yolo_ros` submodule pointer:
  - includes configurable launch support for custom YOLO models
  - includes YOLO corner detection messages and corners adapter

- Update `dji_bringup`:
  - launch the updated `yolo_ros` setup
  - launch the new multi-object EKF estimation pipeline
  - add/update bringup parameters: `YOLO_THRESHOLD`, `YOLO_ENABLE`, and `OBJECT_CONFIG_FILE`
  - 'MARKERS_VISUALIZATION_ENABLE': object pose visualization for the estimation output using markers (no visualization allowed with the new message array)

Notes

Some topic/configuration names may still need to be updated after this change:
- `CAM_PROCESSOR_HAPPY_TOPIC` may need to be updated, since detections now rely on the `yolo_ros` package.
- `ENABLE_ALARS_DETECTOR_SERVICE_TOPIC` may need to be changed or removed, the enable service provided by `yolo_ros` can be used instead.
- Update files from `/M350/rviz/yolo_annotation` to `/M350/yolo/dbg_image`