### PR TITLE
Update ALARS labeling training submodule and dji_bringup

### DIFF
--- a/scripts/smarc_bringups/scripts/dji_bringup.sh
+++ b/scripts/smarc_bringups/scripts/dji_bringup.sh
@@ -266,7 +266,7 @@ else
         YOLO_DEVICE=cpu
         CAM_CALIBRATION_FILE="sim_1080p_cam_params.yaml"
         # seems to be doing better in sim
-        YOLO_MODEL="yolo_model_2cls_mixed.pt"
+        YOLO_MODEL="yolo_model_4cls_july.pt" # Updated for sim (+ hook, land_pad), prev was yolo_model_2cls_mixed.pt
     fi
 
     YOLO_CMD="ros2 launch yolo_smarc_actions alars_yolo_corners.launch.py \


### PR DESCRIPTION
Changes:

- Added Docker services for frame selection, automatic labeling, manual correction, dataset merging, training, testing, and model export.
- Added DINOv2 + HDBSCAN frame-selection tools for image folders and ROS 2 rosbags.
- Updated Part 1 and Part 2 labeling scripts/configs for the new Docker workflow.
- Refactored the training pipeline with configurable merge/split, training, testing, and export model.
- Added a folder-level split registry to keep train/val/test assignments stable when adding new datasets.
- Updated the main README and added documentation for the labeling and training pipelines.
- Updated the DJI sim bringup script to use `yolo_model_4cls_july.pt` for the extended sim model with `sam`, `buoy`, `hook`, and `landing_pad`.