### PR TITLE
CI: Build on metal instead of docker

### DIFF
--- a/.github/workflows/build-and-test-humble.yaml
+++ b/.github/workflows/build-and-test-humble.yaml
@@ -35,10 +35,19 @@ jobs:
 
           sudo dpkg -i /tmp/ros2-apt-source.deb
 
+          # GitHub ubuntu-22.04 runners may contain LLVM's versioned
+          # libunwind development package, which conflicts with Ubuntu's
+          # libunwind-dev required by GStreamer.
+          sudo apt-get remove -y \
+          libunwind-13-dev \
+          libunwind-14-dev \
+          libunwind-15-dev || true
+
           sudo apt-get update
           sudo apt-get install -y \
             ros-humble-ros-base \
-            ros-dev-tools
+            ros-dev-tools \
+            libunwind-dev
 
       - name: Check ROS
         shell: bash

--- a/.github/workflows/build-and-test-humble.yaml
+++ b/.github/workflows/build-and-test-humble.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: 
-            path: 'colcon_ws/'
+            path: colcon_ws/${{ github.event.repository.name }}
 
       - name: Install ROS 2 Humble
         shell: bash
@@ -49,15 +49,15 @@ jobs:
 
       - name: Get base submodules
         shell: bash
+        working_directory: colcon_ws/${{ github.event.repository.name }}
         run: |
-            cd ~/colcon_ws/smarc2
             git submodule update --init external_packages/mqtt_bridge/
             git submodule update --init external_packages/ROS-TCP-Endpoint/
 
       - name: Rosdep
         shell: bash
+        working_directory: colcon_ws/${{ github.event.repository.name }}
         run: |
-          cd ~/colcon_ws/smarc2
           sudo apt-get install -y python3-rosdep
           sudo rosdep init
           rosdep update
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build workspace
         shell: bash
+        working_directory: colcon_ws
         run: |
-          cd ~/colcon_ws
           source /opt/ros/humble/setup.bash
           colcon build --symlink-install

--- a/.github/workflows/build-and-test-humble.yaml
+++ b/.github/workflows/build-and-test-humble.yaml
@@ -49,14 +49,14 @@ jobs:
 
       - name: Get base submodules
         shell: bash
-        working_directory: colcon_ws/src/${{ github.event.repository.name }}
+        working-directory: colcon_ws/src/${{ github.event.repository.name }}
         run: |
             git submodule update --init external_packages/mqtt_bridge/
             git submodule update --init external_packages/ROS-TCP-Endpoint/
 
       - name: Rosdep
         shell: bash
-        working_directory: colcon_ws
+        working-directory: colcon_ws
         run: |
           sudo apt-get install -y python3-rosdep
           sudo rosdep init
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build workspace
         shell: bash
-        working_directory: colcon_ws
+        working-directory: colcon_ws
         run: |
           source /opt/ros/humble/setup.bash
           colcon build --symlink-install

--- a/.github/workflows/build-and-test-humble.yaml
+++ b/.github/workflows/build-and-test-humble.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with: 
             path: colcon_ws/src/${{ github.event.repository.name }}
 

--- a/.github/workflows/build-and-test-humble.yaml
+++ b/.github/workflows/build-and-test-humble.yaml
@@ -1,0 +1,72 @@
+# .github/workflows/build-and-test-humble.yaml
+
+name: Build ROS2 Humble workspace(and run tests)
+
+on:
+  push:
+    branches: [humble, gh_workflow_testing]
+  pull_request:
+    branches: [humble, gh_workflow_testing]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with: 
+            path: 'colcon_ws/'
+
+      - name: Install ROS 2 Humble
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common curl
+          sudo add-apt-repository universe
+
+          export ROS_APT_SOURCE_VERSION=$(
+            curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest \
+            | grep -F "tag_name" \
+            | awk -F'"' '{print $4}'
+          )
+
+          curl -L -o /tmp/ros2-apt-source.deb \
+            "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.jammy_all.deb"
+
+          sudo dpkg -i /tmp/ros2-apt-source.deb
+
+          sudo apt-get update
+          sudo apt-get install -y \
+            ros-humble-ros-base \
+            ros-dev-tools
+
+      - name: Check ROS
+        shell: bash
+        run: |
+          source /opt/ros/humble/setup.bash
+          ros2 --help
+
+
+      - name: Get base submodules
+        shell: bash
+        run: |
+            cd ~/colcon_ws/smarc2
+            git submodule update --init external_packages/mqtt_bridge/
+            git submodule update --init external_packages/ROS-TCP-Endpoint/
+
+      - name: Rosdep
+        shell: bash
+        run: |
+          cd ~/colcon_ws/smarc2
+          sudo apt-get install -y python3-rosdep
+          sudo rosdep init
+          rosdep update
+          source /opt/ros/humble/setup.bash
+          rosdep install --from-paths src --ignore-src -r -y
+
+      - name: Build workspace
+        shell: bash
+        run: |
+          cd ~/colcon_ws
+          source /opt/ros/humble/setup.bash
+          colcon build --symlink-install

--- a/.github/workflows/build-and-test-humble.yaml
+++ b/.github/workflows/build-and-test-humble.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: 
-            path: colcon_ws/${{ github.event.repository.name }}
+            path: colcon_ws/src/${{ github.event.repository.name }}
 
       - name: Install ROS 2 Humble
         shell: bash
@@ -49,14 +49,14 @@ jobs:
 
       - name: Get base submodules
         shell: bash
-        working_directory: colcon_ws/${{ github.event.repository.name }}
+        working_directory: colcon_ws/src/${{ github.event.repository.name }}
         run: |
             git submodule update --init external_packages/mqtt_bridge/
             git submodule update --init external_packages/ROS-TCP-Endpoint/
 
       - name: Rosdep
         shell: bash
-        working_directory: colcon_ws/${{ github.event.repository.name }}
+        working_directory: colcon_ws
         run: |
           sudo apt-get install -y python3-rosdep
           sudo rosdep init

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,18 +1,18 @@
-name: test-colcon-build
+# name: test-colcon-build
 
-on:
-  push:
-    branches:
-        - humble
-        - gh_workflow_testing
-  pull_request:
-    branches:
-        - humble
+# on:
+#   push:
+#     branches:
+#         - humble
+#         - gh_workflow_testing
+#   pull_request:
+#     branches:
+#         - humble
 
-jobs:
-  build:
-    runs-on: ubuntu-22.04
-    steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build -t smarc2/base --build-arg UID=$(id -u) --build-arg GID=$(id -g) --build-arg USERNAME=$(whoami)  -f docker/Dockerfile .
+# jobs:
+#   build:
+#     runs-on: ubuntu-22.04
+#     steps:
+#     - uses: actions/checkout@v4
+#     - name: Build the Docker image
+#       run: docker build -t smarc2/base --build-arg UID=$(id -u) --build-arg GID=$(id -g) --build-arg USERNAME=$(whoami)  -f docker/Dockerfile .


### PR DESCRIPTION
It takes 2m longer than the docker version because of installing ROS2 from scratch instead of using the pre-built docker image, but this way its way easier to add tests that needs to run on a built workspace (wink wink nudge nudge).
Simply add your testing script/steps at the end of the build-and-test-humble.yaml, exactly like how you would run them on your own machine! 
